### PR TITLE
[codex] add root process id setter

### DIFF
--- a/packages/process-explorer-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/process-explorer-worker/src/parts/CommandMap/CommandMap.ts
@@ -26,6 +26,7 @@ import * as Refresh from '../Refresh/Refresh.ts'
 import * as Render2 from '../Render2/Render2.ts'
 import * as RenderEventListeners from '../RenderEventListeners/RenderEventListeners.ts'
 import * as SetError from '../SetError/SetError.ts'
+import * as SetRootProcessId from '../SetRootProcessId/SetRootProcessId.ts'
 
 export const commandMap = {
   'ProcessExplorer.collapseAll': ProcessExplorerStates.wrapCommand(
@@ -91,6 +92,9 @@ export const commandMap = {
     RenderEventListeners.renderEventListeners,
   'ProcessExplorer.setError': ProcessExplorerStates.wrapCommand(
     SetError.setError,
+  ),
+  'ProcessExplorer.setRootProcessId': ProcessExplorerStates.wrapCommand(
+    SetRootProcessId.setRootProcessId,
   ),
   'ProcessExplorer.terminate': terminate,
   'ProcessExplorer.update': ProcessExplorerStates.wrapCommand(Refresh.refresh),

--- a/packages/process-explorer-worker/src/parts/Create/Create.ts
+++ b/packages/process-explorer-worker/src/parts/Create/Create.ts
@@ -40,7 +40,7 @@ export const create = (
     parentUid,
     platform,
     processes: [],
-    rootPid: 0,
+    rootPid: -1,
     uid: id,
     visibleProcesses: [],
     width,

--- a/packages/process-explorer-worker/src/parts/CreateDefaultState/CreateDefaultState.ts
+++ b/packages/process-explorer-worker/src/parts/CreateDefaultState/CreateDefaultState.ts
@@ -15,7 +15,7 @@ export const createDefaultState = (): ProcessExplorerState => ({
   parentUid: 0,
   platform: 0,
   processes: [],
-  rootPid: 0,
+  rootPid: -1,
   uid: 1,
   visibleProcesses: [],
   width: 100,

--- a/packages/process-explorer-worker/src/parts/Refresh/Refresh.ts
+++ b/packages/process-explorer-worker/src/parts/Refresh/Refresh.ts
@@ -27,10 +27,11 @@ export const refresh = async (
     await InitializeProcessExplorer.initializeProcessExplorer(state.platform)
     const includeElectronData = state.platform === PlatformType.Electron
     const rootPid =
-      state.rootPid ||
-      (await ProcessExplorerModule.invoke('ProcessId.getMainProcessId', {
-        includeElectronData,
-      }))
+      state.rootPid === -1
+        ? await ProcessExplorerModule.invoke('ProcessId.getMainProcessId', {
+            includeElectronData,
+          })
+        : state.rootPid
     const processes: readonly ProcessInfo[] =
       await ProcessExplorerModule.invoke(
         'ListProcessesWithMemoryUsage.listProcessesWithMemoryUsage',

--- a/packages/process-explorer-worker/src/parts/SetRootProcessId/SetRootProcessId.ts
+++ b/packages/process-explorer-worker/src/parts/SetRootProcessId/SetRootProcessId.ts
@@ -1,0 +1,11 @@
+import type { ProcessExplorerState } from '../ProcessExplorerState/ProcessExplorerState.ts'
+
+export const setRootProcessId = (
+  state: ProcessExplorerState,
+  rootPid: number,
+): ProcessExplorerState => {
+  return {
+    ...state,
+    rootPid,
+  }
+}

--- a/packages/process-explorer-worker/test/CommandMap.test.ts
+++ b/packages/process-explorer-worker/test/CommandMap.test.ts
@@ -17,4 +17,7 @@ test('commandMap exposes context menu commands', () => {
   expect(CommandMap.commandMap['ProcessExplorer.setError']).toEqual(
     expect.any(Function),
   )
+  expect(CommandMap.commandMap['ProcessExplorer.setRootProcessId']).toEqual(
+    expect.any(Function),
+  )
 })

--- a/packages/process-explorer-worker/test/Create.test.ts
+++ b/packages/process-explorer-worker/test/Create.test.ts
@@ -11,6 +11,7 @@ test('create', () => {
     initial: true,
     parentUid: 5,
     platform: 0,
+    rootPid: -1,
     uid: 7,
     width: 300,
     x: 1,

--- a/packages/process-explorer-worker/test/CreateDefaultState.test.ts
+++ b/packages/process-explorer-worker/test/CreateDefaultState.test.ts
@@ -11,7 +11,7 @@ test('createDefaultState', () => {
     focusedIndex: -1,
     platform: 0,
     processes: [],
-    rootPid: 0,
+    rootPid: -1,
     visibleProcesses: [],
   })
 })

--- a/packages/process-explorer-worker/test/Refresh.test.ts
+++ b/packages/process-explorer-worker/test/Refresh.test.ts
@@ -166,6 +166,26 @@ test('refresh - uses existing root pid', async () => {
   expect(listProcessesWithMemoryUsage).toHaveBeenCalledWith(1, false)
 })
 
+test('refresh - reuses root pid after first refresh', async () => {
+  const listProcessesWithMemoryUsage = jest.fn(
+    (..._args: readonly unknown[]) => processes,
+  )
+  const getMainProcessId = jest.fn((..._args: readonly unknown[]) => 1)
+  using _mockRpc = registerProcessExplorerMock({
+    'ListProcessesWithMemoryUsage.listProcessesWithMemoryUsage':
+      listProcessesWithMemoryUsage,
+    'ProcessId.getMainProcessId': getMainProcessId,
+  })
+  const firstResult = await Refresh.refresh(createDefaultState())
+  const secondResult = await Refresh.refresh(firstResult)
+
+  expect(secondResult.rootPid).toBe(1)
+  expect(getMainProcessId).toHaveBeenCalledTimes(1)
+  expect(listProcessesWithMemoryUsage).toHaveBeenCalledTimes(2)
+  expect(listProcessesWithMemoryUsage).toHaveBeenNthCalledWith(1, 1, false)
+  expect(listProcessesWithMemoryUsage).toHaveBeenNthCalledWith(2, 1, false)
+})
+
 test('refresh - includes frontend memory usage', async () => {
   setPerformance({
     measureUserAgentSpecificMemory: jest.fn(async () => ({

--- a/packages/process-explorer-worker/test/SetRootProcessId.test.ts
+++ b/packages/process-explorer-worker/test/SetRootProcessId.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@jest/globals'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import * as SetRootProcessId from '../src/parts/SetRootProcessId/SetRootProcessId.ts'
+
+test('setRootProcessId', () => {
+  const state = createDefaultState()
+  const result = SetRootProcessId.setRootProcessId(state, 123)
+
+  expect(result).toEqual({
+    ...state,
+    rootPid: 123,
+  })
+})


### PR DESCRIPTION
## Summary

- add `ProcessExplorer.setRootProcessId` for updating the worker root process id
- initialize unknown `rootPid` as `-1`
- reuse the resolved root process id after the first refresh instead of re-requesting it

## Impact

This avoids repeated `ProcessId.getMainProcessId` calls after the process explorer has already resolved the root PID, while preserving the existing backend process-listing API.

## Validation

- `cd packages/process-explorer-worker && npm test`