### PR TITLE
feature: process explorer rpc ref counting

### DIFF
--- a/packages/process-explorer-worker/src/parts/Dispose/Dispose.ts
+++ b/packages/process-explorer-worker/src/parts/Dispose/Dispose.ts
@@ -1,7 +1,11 @@
 import * as AutoRefresh from '../AutoRefresh/AutoRefresh.ts'
+import * as InitializeProcessExplorer from '../InitializeProcessExplorer/InitializeProcessExplorer.ts'
 import * as ProcessExplorerStates from '../ProcessExplorerStates/ProcessExplorerStates.ts'
 
-export const dispose = (uid: number): void => {
+export const dispose = async (uid: number): Promise<void> => {
   AutoRefresh.dispose(uid)
   ProcessExplorerStates.dispose(uid)
+  if (ProcessExplorerStates.getKeys().length === 0) {
+    await InitializeProcessExplorer.dispose()
+  }
 }

--- a/packages/process-explorer-worker/src/parts/InitializeProcessExplorer/InitializeProcessExplorer.ts
+++ b/packages/process-explorer-worker/src/parts/InitializeProcessExplorer/InitializeProcessExplorer.ts
@@ -34,3 +34,8 @@ export const initializeProcessExplorer = async (
 export const clear = (): void => {
   state.initializedPlatform = 0
 }
+
+export const dispose = async (): Promise<void> => {
+  state.initializedPlatform = 0
+  await ProcessExplorerModule.dispose()
+}

--- a/packages/process-explorer-worker/src/parts/ProcessExplorer/ProcessExplorer.ts
+++ b/packages/process-explorer-worker/src/parts/ProcessExplorer/ProcessExplorer.ts
@@ -25,3 +25,9 @@ export const set = (newRpc: Rpc): void => {
 export const clear = (): void => {
   state.rpc = undefined
 }
+
+export const dispose = async (): Promise<void> => {
+  const { rpc } = state
+  state.rpc = undefined
+  await rpc?.dispose()
+}

--- a/packages/process-explorer-worker/test/AutoRefresh.test.ts
+++ b/packages/process-explorer-worker/test/AutoRefresh.test.ts
@@ -92,7 +92,7 @@ test('auto refresh - dispose clears interval and state', async () => {
   createState(7)
 
   AutoRefresh.start(7, 100)
-  Dispose.dispose(7)
+  await Dispose.dispose(7)
   await jest.advanceTimersByTimeAsync(100)
 
   expect(update).not.toHaveBeenCalled()

--- a/packages/process-explorer-worker/test/Dispose.test.ts
+++ b/packages/process-explorer-worker/test/Dispose.test.ts
@@ -1,0 +1,51 @@
+import type { Rpc } from '@lvce-editor/rpc'
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import * as Dispose from '../src/parts/Dispose/Dispose.ts'
+import * as ProcessExplorer from '../src/parts/ProcessExplorer/ProcessExplorer.ts'
+import * as ProcessExplorerStates from '../src/parts/ProcessExplorerStates/ProcessExplorerStates.ts'
+
+const createRpc = (): Rpc => ({
+  dispose: jest.fn(async () => {}),
+  invoke: jest.fn(async () => {}),
+  invokeAndTransfer: jest.fn(async () => {}),
+  send: jest.fn(),
+})
+
+const createState = (uid: number): void => {
+  const state = {
+    ...createDefaultState(),
+    uid,
+  }
+  ProcessExplorerStates.set(uid, state, state)
+}
+
+beforeEach(() => {
+  ProcessExplorer.clear()
+  ProcessExplorerStates.clear()
+  jest.clearAllMocks()
+})
+
+test('dispose - keeps process explorer rpc when other states remain', async () => {
+  createState(1)
+  createState(2)
+  const rpc = createRpc()
+  ProcessExplorer.set(rpc)
+
+  await Dispose.dispose(1)
+
+  expect(ProcessExplorerStates.get(1)).toBeUndefined()
+  expect(ProcessExplorerStates.get(2)).toBeDefined()
+  expect(rpc.dispose).not.toHaveBeenCalled()
+})
+
+test('dispose - disposes process explorer rpc when last state closes', async () => {
+  createState(1)
+  const rpc = createRpc()
+  ProcessExplorer.set(rpc)
+
+  await Dispose.dispose(1)
+
+  expect(ProcessExplorerStates.get(1)).toBeUndefined()
+  expect(rpc.dispose).toHaveBeenCalledTimes(1)
+})

--- a/packages/process-explorer-worker/test/ProcessExplorerRpc.test.ts
+++ b/packages/process-explorer-worker/test/ProcessExplorerRpc.test.ts
@@ -1,0 +1,22 @@
+import type { Rpc } from '@lvce-editor/rpc'
+import { expect, jest, test } from '@jest/globals'
+import * as ProcessExplorer from '../src/parts/ProcessExplorer/ProcessExplorer.ts'
+
+const createRpc = (): Rpc => ({
+  dispose: jest.fn(async () => {}),
+  invoke: jest.fn(async () => {}),
+  invokeAndTransfer: jest.fn(async () => {}),
+  send: jest.fn(),
+})
+
+test('dispose', async () => {
+  const rpc = createRpc()
+  ProcessExplorer.set(rpc)
+
+  await ProcessExplorer.dispose()
+
+  expect(rpc.dispose).toHaveBeenCalledTimes(1)
+  await expect(ProcessExplorer.invoke('test')).rejects.toThrow(
+    'ProcessExplorerModule is not initialized',
+  )
+})

--- a/packages/process-explorer/src/parts/Exit/Exit.ts
+++ b/packages/process-explorer/src/parts/Exit/Exit.ts
@@ -1,0 +1,4 @@
+export const exit = (): void => {
+  process.exitCode = 0
+  process.kill(process.pid, 'SIGTERM')
+}

--- a/packages/process-explorer/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/process-explorer/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -1,6 +1,7 @@
 import { ElectronMessagePortRpcClient } from '@lvce-editor/rpc'
 import * as Assert from '../Assert/Assert.ts'
 import * as CreateMessagePortRpc from '../CreateMessagePortRpc/CreateMessagePortRpc.ts'
+import * as HandleRpcClose from '../HandleRpcClose/HandleRpcClose.ts'
 import * as RpcRegistry from '../RpcRegistry/RpcRegistry.ts'
 
 export const { createMessagePortRpc } = CreateMessagePortRpc
@@ -14,5 +15,6 @@ export const handleMessagePort = async (
     ElectronMessagePortRpcClient.create,
     messagePort,
   )
+  HandleRpcClose.listen(rpc)
   RpcRegistry.setRpc(rpc, rpcId)
 }

--- a/packages/process-explorer/src/parts/HandleRpcClose/HandleRpcClose.ts
+++ b/packages/process-explorer/src/parts/HandleRpcClose/HandleRpcClose.ts
@@ -1,0 +1,68 @@
+import type { Rpc } from '@lvce-editor/rpc'
+import { SharedProcess } from '@lvce-editor/rpc-registry'
+import * as Exit from '../Exit/Exit.ts'
+
+type IpcWithClose =
+  | {
+      readonly addEventListener: (
+        type: string,
+        listener: () => void,
+        options?: { readonly once?: boolean },
+      ) => void
+      readonly removeEventListener?: (
+        type: string,
+        listener: () => void,
+      ) => void
+    }
+  | {
+      readonly on: (type: string, listener: () => void) => void
+      readonly off?: (type: string, listener: () => void) => void
+    }
+
+interface RpcWithIpc extends Rpc {
+  readonly ipc?: IpcWithClose
+}
+
+const removeCloseListener = (ipc: IpcWithClose, listener: () => void): void => {
+  if ('removeEventListener' in ipc && ipc.removeEventListener) {
+    ipc.removeEventListener('close', listener)
+    return
+  }
+  if ('off' in ipc && ipc.off) {
+    ipc.off('close', listener)
+  }
+}
+
+export const handleClose = async (): Promise<void> => {
+  let refCount: number
+  try {
+    refCount = await SharedProcess.invoke('ProcessExplorer.decreaseRefCount')
+  } catch {
+    Exit.exit()
+    return
+  }
+  if (refCount === 0) {
+    Exit.exit()
+  }
+}
+
+export const listen = (rpc: Rpc): void => {
+  const { ipc } = rpc as RpcWithIpc
+  if (!ipc) {
+    return
+  }
+  let didClose = false
+  const listener = (): void => {
+    if (didClose) {
+      return
+    }
+    didClose = true
+    removeCloseListener(ipc, listener)
+    void handleClose()
+  }
+  if ('addEventListener' in ipc) {
+    ipc.addEventListener('close', listener, { once: true })
+    return
+  }
+  ipc.on('close', listener)
+}

--- a/packages/process-explorer/src/parts/HandleWebSocket/HandleWebSocket.ts
+++ b/packages/process-explorer/src/parts/HandleWebSocket/HandleWebSocket.ts
@@ -1,6 +1,7 @@
 import { type Rpc, NodeWebSocketRpcClient } from '@lvce-editor/rpc'
 import * as Assert from '../Assert/Assert.ts'
 import * as GetCommandMap from '../GetCommandMap/GetCommandMap.ts'
+import * as HandleRpcClose from '../HandleRpcClose/HandleRpcClose.ts'
 import * as RequiresSocket from '../RequiresSocket/RequiresSocket.ts'
 import * as RpcRegistry from '../RpcRegistry/RpcRegistry.ts'
 
@@ -41,5 +42,6 @@ export const handleWebSocket = async (
     handle,
     request,
   )
+  HandleRpcClose.listen(rpc)
   RpcRegistry.setRpc(rpc, rpcId)
 }

--- a/packages/process-explorer/src/parts/Listen/Listen.ts
+++ b/packages/process-explorer/src/parts/Listen/Listen.ts
@@ -1,12 +1,20 @@
+import type { Rpc } from '@lvce-editor/rpc'
+import { RpcId } from '@lvce-editor/rpc-registry'
 import * as CommandMap from '../CommandMap/CommandMap.ts'
 import * as CommandMapRef from '../CommandMapRef/CommandMapRef.ts'
 import * as IpcChild from '../IpcChild/IpcChild.ts'
 import * as IpcChildType from '../IpcChildType/IpcChildType.ts'
+import * as RpcRegistry from '../RpcRegistry/RpcRegistry.ts'
+
+export const registerLaunchParentRpc = (rpc: Rpc): void => {
+  RpcRegistry.setRpc(rpc, RpcId.SharedProcess)
+}
 
 export const listen = async (): Promise<void> => {
   CommandMapRef.set(CommandMap.commandMap)
-  await IpcChild.listen({
+  const rpc = await IpcChild.listen({
     commandMap: CommandMap.commandMap,
     method: IpcChildType.Auto(),
   })
+  registerLaunchParentRpc(rpc)
 }

--- a/packages/process-explorer/test/HandleRpcClose.test.ts
+++ b/packages/process-explorer/test/HandleRpcClose.test.ts
@@ -1,0 +1,67 @@
+import type { Rpc } from '@lvce-editor/rpc'
+import { afterEach, expect, jest, test } from '@jest/globals'
+import { SharedProcess } from '@lvce-editor/rpc-registry'
+import * as HandleRpcClose from '../src/parts/HandleRpcClose/HandleRpcClose.ts'
+
+const createRpc = (ipc: unknown): Rpc => {
+  return {
+    dispose: jest.fn(async () => {}),
+    invoke: jest.fn(async () => {}),
+    invokeAndTransfer: jest.fn(async () => {}),
+    ipc,
+    send: jest.fn(),
+  } as Rpc
+}
+
+afterEach(() => {
+  jest.restoreAllMocks()
+  process.exitCode = undefined
+})
+
+test('handleClose - keeps process alive when ref count remains', async () => {
+  const decreaseRefCount = jest.fn(async () => 1)
+  using _mockRpc = SharedProcess.registerMockRpc({
+    'ProcessExplorer.decreaseRefCount': decreaseRefCount,
+  })
+
+  await HandleRpcClose.handleClose()
+
+  expect(decreaseRefCount).toHaveBeenCalledTimes(1)
+})
+
+test('handleClose - exits when ref count reaches zero', async () => {
+  const kill = jest.spyOn(process, 'kill').mockImplementation(() => true)
+  const decreaseRefCount = jest.fn(async () => 0)
+  using _mockRpc = SharedProcess.registerMockRpc({
+    'ProcessExplorer.decreaseRefCount': decreaseRefCount,
+  })
+
+  await HandleRpcClose.handleClose()
+
+  expect(decreaseRefCount).toHaveBeenCalledTimes(1)
+  expect(kill).toHaveBeenCalledWith(process.pid, 'SIGTERM')
+  expect(process.exitCode).toBe(0)
+})
+
+test('listen - decrements once when rpc closes', async () => {
+  const decreaseRefCount = jest.fn(async () => 1)
+  using _mockRpc = SharedProcess.registerMockRpc({
+    'ProcessExplorer.decreaseRefCount': decreaseRefCount,
+  })
+  const listeners: Array<() => void> = []
+  const ipc = {
+    off: jest.fn(),
+    on: jest.fn((_event: string, listener: () => void) => {
+      listeners.push(listener)
+    }),
+  }
+  const rpc = createRpc(ipc)
+
+  HandleRpcClose.listen(rpc)
+  listeners[0]()
+  listeners[0]()
+  await Promise.resolve()
+
+  expect(decreaseRefCount).toHaveBeenCalledTimes(1)
+  expect(ipc.off).toHaveBeenCalledWith('close', listeners[0])
+})

--- a/packages/process-explorer/test/Listen.test.ts
+++ b/packages/process-explorer/test/Listen.test.ts
@@ -1,0 +1,19 @@
+import type { Rpc } from '@lvce-editor/rpc'
+import { expect, jest, test } from '@jest/globals'
+import { get, remove, RpcId } from '@lvce-editor/rpc-registry'
+import * as Listen from '../src/parts/Listen/Listen.ts'
+
+const mockRpc: Rpc = {
+  dispose: jest.fn(async () => {}),
+  invoke: jest.fn(async () => {}),
+  invokeAndTransfer: jest.fn(async () => {}),
+  send: jest.fn(),
+}
+
+test('registerLaunchParentRpc', () => {
+  remove(RpcId.SharedProcess)
+
+  Listen.registerLaunchParentRpc(mockRpc)
+
+  expect(get(RpcId.SharedProcess)).toBe(mockRpc)
+})


### PR DESCRIPTION
## Summary
- dispose the frontend process-explorer RPC when the last view closes
- register the process-explorer launch parent as the shared-process RPC
- decrement shared-process ref counts when process-explorer client RPCs close

## Validation
- npm run type-check
- npm run lint
- npm test in packages/process-explorer
- npm test in packages/process-explorer-worker