### PR TITLE
fix: show process rss memory

### DIFF
--- a/packages/process-explorer/src/parts/ParseMemory/ParseMemory.ts
+++ b/packages/process-explorer/src/parts/ParseMemory/ParseMemory.ts
@@ -5,7 +5,5 @@ export const parseMemory = (content: string): number => {
   const numberBlocks = trimmedContent.split(Character.Space)
   const pageSize = 4096
   const rss = Number.parseInt(numberBlocks[1]) * pageSize
-  const shared = Number.parseInt(numberBlocks[2]) * pageSize
-  const memory = rss - shared
-  return memory
+  return rss
 }

--- a/packages/process-explorer/test/ListProcessesWithMemoryUsageUnix.test.ts
+++ b/packages/process-explorer/test/ListProcessesWithMemoryUsageUnix.test.ts
@@ -72,7 +72,7 @@ test('listProcessesWithMemoryUsage', async () => {
     {
       cmd: '/usr/libexec/gsd-keyboard',
       depth: 1,
-      memory: 3_375_104,
+      memory: 8_286_208,
       name: '/usr/libexec/gsd-keyboard',
       pid: 2127,
       ppid: 1442,
@@ -80,7 +80,7 @@ test('listProcessesWithMemoryUsage', async () => {
     {
       cmd: '/usr/libexec/gsd-media-keys',
       depth: 1,
-      memory: 3_375_104,
+      memory: 8_286_208,
       name: '/usr/libexec/gsd-media-keys',
       pid: 2130,
       ppid: 1442,
@@ -88,7 +88,7 @@ test('listProcessesWithMemoryUsage', async () => {
     {
       cmd: '/usr/libexec/gsd-power',
       depth: 1,
-      memory: 3_375_104,
+      memory: 8_286_208,
       name: '/usr/libexec/gsd-power',
       pid: 2133,
       ppid: 1442,
@@ -96,7 +96,7 @@ test('listProcessesWithMemoryUsage', async () => {
     {
       cmd: '/usr/libexec/gsd-print-notifications',
       depth: 1,
-      memory: 3_375_104,
+      memory: 8_286_208,
       name: '/usr/libexec/gsd-print-notifications',
       pid: 2134,
       ppid: 1442,
@@ -104,7 +104,7 @@ test('listProcessesWithMemoryUsage', async () => {
     {
       cmd: '/usr/libexec/gsd-rfkill',
       depth: 1,
-      memory: 3_375_104,
+      memory: 8_286_208,
       name: '/usr/libexec/gsd-rfkill',
       pid: 2135,
       ppid: 1442,
@@ -112,7 +112,7 @@ test('listProcessesWithMemoryUsage', async () => {
     {
       cmd: '/usr/libexec/gsd-screensaver-proxy',
       depth: 1,
-      memory: 3_375_104,
+      memory: 8_286_208,
       name: '/usr/libexec/gsd-screensaver-proxy',
       pid: 2136,
       ppid: 1442,
@@ -120,7 +120,7 @@ test('listProcessesWithMemoryUsage', async () => {
     {
       cmd: '/usr/libexec/gsd-sharing',
       depth: 1,
-      memory: 3_375_104,
+      memory: 8_286_208,
       name: '/usr/libexec/gsd-sharing',
       pid: 2138,
       ppid: 1442,
@@ -147,7 +147,7 @@ test('listProcessesWithMemoryUsage - without electron data', async () => {
     {
       cmd: '/usr/libexec/gsd-keyboard',
       depth: 1,
-      memory: 3_375_104,
+      memory: 8_286_208,
       name: '/usr/libexec/gsd-keyboard',
       pid: 2127,
       ppid: 1442,
@@ -173,7 +173,7 @@ test('listProcessesWithMemoryUsage - bug with parsing this specific line', async
     {
       cmd: '/snap/code/97/usr/share/code/code --ms-enable-electron-run-as-node --max-old-space-size=3072 /snap/code/97/usr/share/code/resources/app/extensions/node_modules/typescript/lib/tsserver.js --useInferredProjectPerProjectRoot --disableAutomaticTypingAcquisition --enableTelemetry --cancellationPipeName /tmp/vscode-typescript1000/25df66cb1c287c2f519c/tscancellation-9462d6e60479e4eb5d2f.tmp* --locale en --noGetErrOnBackgroundUpdate --validateDefaultNpmLocation --useNodeIpc',
       depth: 1,
-      memory: 3_375_104,
+      memory: 8_286_208,
       name: 'main',
       pid: 25_666,
       ppid: 24_775,
@@ -208,7 +208,7 @@ test('listProcessesWithMemoryUsage - detect chrome devtools', async () => {
     {
       cmd: '/snap/code/97/usr/share/code/code --ms-enable-electron-run-as-node --max-old-space-size=3072 /snap/code/97/usr/share/code/resources/app/extensions/node_modules/typescript/lib/tsserver.js --useInferredProjectPerProjectRoot --disableAutomaticTypingAcquisition --enableTelemetry --cancellationPipeName /tmp/vscode-typescript1000/25df66cb1c287c2f519c/tscancellation-9462d6e60479e4eb5d2f.tmp* --locale en --noGetErrOnBackgroundUpdate --validateDefaultNpmLocation --useNodeIpc',
       depth: 1,
-      memory: 3_375_104,
+      memory: 8_286_208,
       name: 'main',
       pid: 25_666,
       ppid: 24_775,
@@ -241,7 +241,7 @@ test('listProcessesWithMemoryUsage - error - ESRCH', async () => {
     {
       cmd: '/usr/libexec/gsd-media-keys',
       depth: 1,
-      memory: 3_375_104,
+      memory: 8_286_208,
       name: '/usr/libexec/gsd-media-keys',
       pid: 2130,
       ppid: 1442,

--- a/packages/process-explorer/test/ParseMemory.test.ts
+++ b/packages/process-explorer/test/ParseMemory.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@jest/globals'
+import * as ParseMemory from '../src/parts/ParseMemory/ParseMemory.ts'
+
+test('parseMemory - returns resident set size', () => {
+  expect(ParseMemory.parseMemory('41700 2023 1199 224 0 5027 0')).toBe(
+    8_286_208,
+  )
+})
+
+test('parseMemory - does not subtract shared memory', () => {
+  expect(ParseMemory.parseMemory('6500 6250 6000 224 0 5027 0')).toBe(
+    25_600_000,
+  )
+})

--- a/packages/process-explorer/test/ProcessUtilities.test.ts
+++ b/packages/process-explorer/test/ProcessUtilities.test.ts
@@ -8,7 +8,7 @@ import * as RequiresSocket from '../src/parts/RequiresSocket/RequiresSocket.ts'
 import * as SplitLines from '../src/parts/SplitLines/SplitLines.ts'
 
 test('parseMemory', () => {
-  expect(ParseMemory.parseMemory('100 5 2 0 0 0 0')).toBe(12_288)
+  expect(ParseMemory.parseMemory('100 5 2 0 0 0 0')).toBe(20_480)
 })
 
 test('hasPositiveMemoryUsage', () => {


### PR DESCRIPTION
Fix Process Explorer memory values on Linux by reporting resident memory from /proc/<pid>/statm instead of subtracting shared pages from RSS. This avoids tiny misleading values for Electron/Node processes with large shared mappings.