### PR TITLE
fix: highlight process explorer row on click

### DIFF
--- a/packages/e2e/src/viewlet.process-explorer.click-highlight.ts
+++ b/packages/e2e/src/viewlet.process-explorer.click-highlight.ts
@@ -1,0 +1,28 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.click-highlight'
+
+const defaultUpdateInterval = 1000
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+  await Command.execute('ProcessExplorer.setUpdateInterval', -1)
+  const nameCell = Locator('.ProcessExplorerNameCell[data-index="0"]')
+  const focusedRow = Locator('.ProcessExplorerRowFocused[data-index="0"]')
+  await expect(nameCell).toBeVisible()
+
+  try {
+    // act
+    // eslint-disable-next-line e2e/no-direct-click -- verifies real process explorer row click updates the highlight immediately
+    await nameCell.click()
+
+    // assert
+    await expect(focusedRow).toBeVisible()
+  } finally {
+    await Command.execute(
+      'ProcessExplorer.setUpdateInterval',
+      defaultUpdateInterval,
+    )
+  }
+}

--- a/packages/process-explorer-worker/src/parts/AutoRefresh/AutoRefresh.ts
+++ b/packages/process-explorer-worker/src/parts/AutoRefresh/AutoRefresh.ts
@@ -42,11 +42,16 @@ export const start = (
   uid: number,
   interval: number = ProcessExplorerUpdateInterval.processExplorerUpdateInterval,
 ): void => {
-  if (interval === 0 || intervals.has(uid)) {
+  if (interval <= 0 || intervals.has(uid)) {
     return
   }
   const intervalId = setInterval(() => {
     void update(uid)
   }, interval)
   intervals.set(uid, intervalId)
+}
+
+export const restart = (uid: number, interval: number): void => {
+  dispose(uid)
+  start(uid, interval)
 }

--- a/packages/process-explorer-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/process-explorer-worker/src/parts/CommandMap/CommandMap.ts
@@ -28,6 +28,7 @@ import * as Render2 from '../Render2/Render2.ts'
 import * as RenderEventListeners from '../RenderEventListeners/RenderEventListeners.ts'
 import * as SetError from '../SetError/SetError.ts'
 import * as SetRootProcessId from '../SetRootProcessId/SetRootProcessId.ts'
+import * as SetUpdateInterval from '../SetUpdateInterval/SetUpdateInterval.ts'
 
 export const commandMap = {
   'ProcessExplorer.collapseAll': ProcessExplorerStates.wrapCommand(
@@ -101,6 +102,9 @@ export const commandMap = {
   ),
   'ProcessExplorer.setRootProcessId': ProcessExplorerStates.wrapCommand(
     SetRootProcessId.setRootProcessId,
+  ),
+  'ProcessExplorer.setUpdateInterval': ProcessExplorerStates.wrapCommand(
+    SetUpdateInterval.setUpdateInterval,
   ),
   'ProcessExplorer.terminate': terminate,
   'ProcessExplorer.update': ProcessExplorerStates.wrapCommand(Refresh.refresh),

--- a/packages/process-explorer-worker/src/parts/Create/Create.ts
+++ b/packages/process-explorer-worker/src/parts/Create/Create.ts
@@ -1,8 +1,10 @@
 import type { ProcessExplorerState } from '../ProcessExplorerState/ProcessExplorerState.ts'
 import * as ProcessExplorerStates from '../ProcessExplorerStates/ProcessExplorerStates.ts'
+import * as ProcessExplorerUpdateInterval from '../ProcessExplorerUpdateInterval/ProcessExplorerUpdateInterval.ts'
 
 interface CreateArgs {
   readonly includeFrontendMemoryUsage?: boolean
+  readonly updateInterval?: number
 }
 
 const getIncludeFrontendMemoryUsage = (args: unknown): boolean => {
@@ -11,6 +13,17 @@ const getIncludeFrontendMemoryUsage = (args: unknown): boolean => {
   }
   const createArgs = args as CreateArgs
   return createArgs.includeFrontendMemoryUsage === true
+}
+
+const getUpdateInterval = (args: unknown): number => {
+  if (!args || typeof args !== 'object') {
+    return ProcessExplorerUpdateInterval.processExplorerUpdateInterval
+  }
+  const createArgs = args as CreateArgs
+  if (typeof createArgs.updateInterval !== 'number') {
+    return ProcessExplorerUpdateInterval.processExplorerUpdateInterval
+  }
+  return createArgs.updateInterval
 }
 
 export const create = (
@@ -42,6 +55,7 @@ export const create = (
     processes: [],
     rootPid: -1,
     uid: id,
+    updateInterval: getUpdateInterval(args),
     visibleProcesses: [],
     width,
     x,

--- a/packages/process-explorer-worker/src/parts/CreateDefaultState/CreateDefaultState.ts
+++ b/packages/process-explorer-worker/src/parts/CreateDefaultState/CreateDefaultState.ts
@@ -1,4 +1,5 @@
 import type { ProcessExplorerState } from '../ProcessExplorerState/ProcessExplorerState.ts'
+import * as ProcessExplorerUpdateInterval from '../ProcessExplorerUpdateInterval/ProcessExplorerUpdateInterval.ts'
 
 export const createDefaultState = (): ProcessExplorerState => ({
   assetDir: '',
@@ -17,6 +18,7 @@ export const createDefaultState = (): ProcessExplorerState => ({
   processes: [],
   rootPid: -1,
   uid: 1,
+  updateInterval: ProcessExplorerUpdateInterval.processExplorerUpdateInterval,
   visibleProcesses: [],
   width: 100,
   x: 0,

--- a/packages/process-explorer-worker/src/parts/HandleClickAt/HandleClickAt.ts
+++ b/packages/process-explorer-worker/src/parts/HandleClickAt/HandleClickAt.ts
@@ -3,7 +3,7 @@ import * as FocusIndex from '../FocusIndex/FocusIndex.ts'
 
 export const handleClickAt = (
   state: ProcessExplorerState,
-  index: number,
+  index: number | string,
 ): ProcessExplorerState => {
-  return FocusIndex.focusIndex(state, index)
+  return FocusIndex.focusIndex(state, Number(index))
 }

--- a/packages/process-explorer-worker/src/parts/HandleContextMenu/HandleContextMenu.ts
+++ b/packages/process-explorer-worker/src/parts/HandleContextMenu/HandleContextMenu.ts
@@ -5,22 +5,23 @@ import * as ProcessExplorerStates from '../ProcessExplorerStates/ProcessExplorer
 
 export const handleContextMenu = async (
   state: ProcessExplorerState,
-  index: number = state.focusedIndex,
+  index: number | string = state.focusedIndex,
   x: number = 0,
   y: number = 0,
 ): Promise<ProcessExplorerState> => {
-  const process = state.visibleProcesses[index]
+  const numericIndex = Number(index)
+  const process = state.visibleProcesses[numericIndex]
   if (!process) {
     return state
   }
   const newState: ProcessExplorerState = {
     ...state,
     focused: false,
-    focusedIndex: index,
+    focusedIndex: numericIndex,
   }
   ProcessExplorerStates.set(state.uid, state, newState)
   await ContextMenu.show2(state.uid, MenuEntryId.ProcessExplorer, x, y, {
-    index,
+    index: numericIndex,
     menuId: MenuEntryId.ProcessExplorer,
   })
   return newState

--- a/packages/process-explorer-worker/src/parts/HandleDoubleClick/HandleDoubleClick.ts
+++ b/packages/process-explorer-worker/src/parts/HandleDoubleClick/HandleDoubleClick.ts
@@ -3,7 +3,7 @@ import * as ToggleIndex from '../ToggleIndex/ToggleIndex.ts'
 
 export const handleDoubleClick = (
   state: ProcessExplorerState,
-  index: number = state.focusedIndex,
+  index: number | string = state.focusedIndex,
 ): ProcessExplorerState => {
-  return ToggleIndex.toggleIndex(state, index)
+  return ToggleIndex.toggleIndex(state, Number(index))
 }

--- a/packages/process-explorer-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/process-explorer-worker/src/parts/LoadContent/LoadContent.ts
@@ -12,7 +12,7 @@ export const loadContent = async (
 ): Promise<LoadContentResult<ProcessExplorerState>> => {
   const newState = await Refresh.refresh(state)
   if (!hasError(newState)) {
-    AutoRefresh.start(newState.uid)
+    AutoRefresh.start(newState.uid, newState.updateInterval)
   }
   return {
     error: undefined,

--- a/packages/process-explorer-worker/src/parts/ProcessExplorerState/ProcessExplorerState.ts
+++ b/packages/process-explorer-worker/src/parts/ProcessExplorerState/ProcessExplorerState.ts
@@ -18,6 +18,7 @@ export interface ProcessExplorerState {
   readonly processes: readonly ProcessInfo[]
   readonly rootPid: number
   readonly uid: number
+  readonly updateInterval: number
   readonly visibleProcesses: readonly VisibleProcess[]
   readonly width: number
   readonly x: number

--- a/packages/process-explorer-worker/src/parts/RenderEventListeners/RenderEventListeners.ts
+++ b/packages/process-explorer-worker/src/parts/RenderEventListeners/RenderEventListeners.ts
@@ -14,19 +14,19 @@ export const renderEventListeners = (): readonly DomEventListener[] => {
     },
     {
       name: DomEventListenerFunctions.HandleClick,
-      params: ['handleClickAt', EventExpression.TargetName],
+      params: ['handleClickAt', 'event.target.dataset.index'],
       preventDefault: true,
     },
     {
       name: DomEventListenerFunctions.HandleDoubleClick,
-      params: ['handleDoubleClick', EventExpression.TargetName],
+      params: ['handleDoubleClick', 'event.target.dataset.index'],
       preventDefault: true,
     },
     {
       name: DomEventListenerFunctions.HandleContextMenu,
       params: [
         'handleContextMenu',
-        EventExpression.TargetName,
+        'event.target.dataset.index',
         EventExpression.ClientX,
         EventExpression.ClientY,
       ],
@@ -34,7 +34,7 @@ export const renderEventListeners = (): readonly DomEventListener[] => {
     },
     {
       name: DomEventListenerFunctions.HandlePointerDown,
-      params: ['handleClickAt', EventExpression.TargetName],
+      params: ['handleClickAt', 'event.target.dataset.index'],
     },
   ]
 }

--- a/packages/process-explorer-worker/src/parts/RenderItems/RenderItems.ts
+++ b/packages/process-explorer-worker/src/parts/RenderItems/RenderItems.ts
@@ -48,6 +48,7 @@ const getCellDom = (
     {
       childCount: 1,
       className,
+      'data-index': index,
       name: String(index),
       paddingLeft,
       role: AriaRoles.GridCell,

--- a/packages/process-explorer-worker/src/parts/SetUpdateInterval/SetUpdateInterval.ts
+++ b/packages/process-explorer-worker/src/parts/SetUpdateInterval/SetUpdateInterval.ts
@@ -1,0 +1,13 @@
+import type { ProcessExplorerState } from '../ProcessExplorerState/ProcessExplorerState.ts'
+import * as AutoRefresh from '../AutoRefresh/AutoRefresh.ts'
+
+export const setUpdateInterval = (
+  state: ProcessExplorerState,
+  updateInterval: number,
+): ProcessExplorerState => {
+  AutoRefresh.restart(state.uid, updateInterval)
+  return {
+    ...state,
+    updateInterval,
+  }
+}

--- a/packages/process-explorer-worker/test/AutoRefresh.test.ts
+++ b/packages/process-explorer-worker/test/AutoRefresh.test.ts
@@ -112,3 +112,17 @@ test('auto refresh - zero interval disables updates', async () => {
 
   expect(update).not.toHaveBeenCalled()
 })
+
+test('auto refresh - negative interval disables updates', async () => {
+  jest.useFakeTimers()
+  const update = jest.fn()
+  using _mockRpc = RendererWorker.registerMockRpc({
+    'ProcessExplorer.update': update,
+  })
+  createState(7)
+
+  AutoRefresh.start(7, -1)
+  await jest.advanceTimersByTimeAsync(1000)
+
+  expect(update).not.toHaveBeenCalled()
+})

--- a/packages/process-explorer-worker/test/Create.test.ts
+++ b/packages/process-explorer-worker/test/Create.test.ts
@@ -36,8 +36,15 @@ test('create - defaults and include frontend memory usage', () => {
     assetDir: '',
     includeFrontendMemoryUsage: true,
     platform: 0,
+    updateInterval: 1000,
   })
   expect(ProcessExplorerStates.get(8).newState).toBe(state)
+})
+
+test('create - update interval', () => {
+  ProcessExplorerStates.clear()
+  const state = create(10, '', 1, 2, 300, 400, { updateInterval: -1 }, 5)
+  expect(state.updateInterval).toBe(-1)
 })
 
 test('create - missing args', () => {

--- a/packages/process-explorer-worker/test/HandleContextMenu.test.ts
+++ b/packages/process-explorer-worker/test/HandleContextMenu.test.ts
@@ -79,6 +79,35 @@ test('handleContextMenu - invalid index', async () => {
   expect(mockRpc.invocations).toEqual([])
 })
 
+test('handleContextMenu - string index', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ContextMenu.show2': () => undefined,
+  })
+  const state = {
+    ...createDefaultState(),
+    visibleProcesses: GetVisibleProcesses.getVisibleProcesses(processes, [], 1),
+  }
+  const result = await HandleContextMenu.handleContextMenu(state, '1', 10, 20)
+  expect(result).toEqual({
+    ...state,
+    focused: false,
+    focusedIndex: 1,
+  })
+  expect(mockRpc.invocations).toEqual([
+    [
+      'ContextMenu.show2',
+      state.uid,
+      MenuEntryId.ProcessExplorer,
+      10,
+      20,
+      {
+        index: 1,
+        menuId: MenuEntryId.ProcessExplorer,
+      },
+    ],
+  ])
+})
+
 test('handleContextMenu - defaults', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'ContextMenu.show2': () => undefined,

--- a/packages/process-explorer-worker/test/HandleDoubleClick.test.ts
+++ b/packages/process-explorer-worker/test/HandleDoubleClick.test.ts
@@ -58,3 +58,17 @@ test('handleDoubleClick - default index', () => {
 
   expect(HandleDoubleClick.handleDoubleClick(state).collapsedPids).toEqual([1])
 })
+
+test('handleDoubleClick - string index', () => {
+  const state = {
+    ...createDefaultState(),
+    focusedIndex: 0,
+    processes,
+    rootPid: 1,
+    visibleProcesses: GetVisibleProcesses.getVisibleProcesses(processes, [], 1),
+  }
+
+  expect(HandleDoubleClick.handleDoubleClick(state, '0').collapsedPids).toEqual(
+    [1],
+  )
+})

--- a/packages/process-explorer-worker/test/RenderEventListeners.test.ts
+++ b/packages/process-explorer-worker/test/RenderEventListeners.test.ts
@@ -7,7 +7,7 @@ test('renderEventListeners', () => {
     expect.arrayContaining([
       expect.objectContaining({
         name: DomEventListenerFunctions.HandleClick,
-        params: ['handleClickAt', 'event.target.name'],
+        params: ['handleClickAt', 'event.target.dataset.index'],
       }),
       expect.objectContaining({
         name: DomEventListenerFunctions.HandleContextMenu,

--- a/packages/process-explorer-worker/test/SetUpdateInterval.test.ts
+++ b/packages/process-explorer-worker/test/SetUpdateInterval.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import * as AutoRefresh from '../src/parts/AutoRefresh/AutoRefresh.ts'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import * as ProcessExplorerStates from '../src/parts/ProcessExplorerStates/ProcessExplorerStates.ts'
+import * as SetUpdateInterval from '../src/parts/SetUpdateInterval/SetUpdateInterval.ts'
+
+afterEach(() => {
+  AutoRefresh.clear()
+  ProcessExplorerStates.clear()
+  jest.useRealTimers()
+})
+
+test('setUpdateInterval - disables existing interval', async () => {
+  jest.useFakeTimers()
+  const update = jest.fn()
+  using _mockRpc = RendererWorker.registerMockRpc({
+    'ProcessExplorer.update': update,
+  })
+  const state = {
+    ...createDefaultState(),
+    uid: 7,
+  }
+  ProcessExplorerStates.set(7, state, state)
+  AutoRefresh.start(7, 100)
+
+  const result = SetUpdateInterval.setUpdateInterval(state, -1)
+  await jest.advanceTimersByTimeAsync(100)
+
+  expect(result.updateInterval).toBe(-1)
+  expect(update).not.toHaveBeenCalled()
+})

--- a/packages/process-explorer-worker/test/SimpleHandlers.test.ts
+++ b/packages/process-explorer-worker/test/SimpleHandlers.test.ts
@@ -57,6 +57,15 @@ test('handleClickAt', () => {
   expect(HandleClickAt.handleClickAt(state, 1).focusedIndex).toBe(1)
 })
 
+test('handleClickAt - string index', () => {
+  const state = {
+    ...createDefaultState(),
+    visibleProcesses: GetVisibleProcesses.getVisibleProcesses(processes, [], 1),
+  }
+
+  expect(HandleClickAt.handleClickAt(state, '1').focusedIndex).toBe(1)
+})
+
 test('getMenuEntryIds', () => {
   expect(GetMenuEntryIds.getMenuEntryIds()).toEqual([
     MenuEntryId.ProcessExplorer,


### PR DESCRIPTION
## Summary
- use row data-index for process explorer click, double-click, context menu, and pointerdown handling
- add a process explorer update interval command so e2e tests can disable auto refresh
- add e2e coverage verifying a clicked row highlights immediately with updates disabled

## Verification
- npm run lint
- npm run type-check
- npm test -- --scope @lvce-editor/process-explorer-worker -- --runInBand
- npm run build
- npm run e2e:headless -- --filter=viewlet.process-explorer.click-highlight