### PR TITLE
feature: use rollup for production builds

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -12,6 +12,7 @@
         "@babel/preset-typescript": "^7.28.5",
         "@lvce-editor/verror": "^1.7.0",
         "@rollup/plugin-babel": "^7.1.0",
+        "@rollup/plugin-commonjs": "^29.0.3",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@types/node": "^25.0.8",
         "esbuild": "^0.28.1",
@@ -984,6 +985,33 @@
         }
       }
     },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-29.0.3.tgz",
+      "integrity": "sha512-ZaOxZceP7SOUW7Lqw5IRVweSQYWaeIPnXIGLiB690EBA3FGJTO40EEr2L5yZplJWsgTCogILRSpcAe7+U0Otdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "fdir": "^6.2.0",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0 || 14 >= 14.17"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
@@ -1536,6 +1564,13 @@
       "license": "CC-BY-4.0",
       "peer": true
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1692,6 +1727,24 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/figures": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -1820,6 +1873,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/is-stream": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
@@ -1896,6 +1959,16 @@
       "peer": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/ms": {

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -12,6 +12,7 @@
     "@babel/preset-typescript": "^7.28.5",
     "@lvce-editor/verror": "^1.7.0",
     "@rollup/plugin-babel": "^7.1.0",
+    "@rollup/plugin-commonjs": "^29.0.3",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@types/node": "^25.0.8",
     "esbuild": "^0.28.1",

--- a/packages/build/src/bundleJs.ts
+++ b/packages/build/src/bundleJs.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path'
 import { VError } from '@lvce-editor/verror'
 import pluginTypeScript from '@babel/preset-typescript'
 import { babel } from '@rollup/plugin-babel'
+import commonjs from '@rollup/plugin-commonjs'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import {
   rollup,
@@ -9,6 +10,9 @@ import {
   type OutputOptions,
   type RollupOptions,
 } from 'rollup'
+
+const commonjsPlugin =
+  commonjs as unknown as typeof import('@rollup/plugin-commonjs').default
 
 interface BundleJsOptions {
   readonly cwd: string
@@ -35,6 +39,7 @@ export const bundleJs = async ({
         browser,
         preferBuiltins: true,
       }),
+      commonjsPlugin(),
     ]
     if (typescript) {
       plugins.push(

--- a/packages/build/src/bundleNodeJs.ts
+++ b/packages/build/src/bundleNodeJs.ts
@@ -1,6 +1,5 @@
-import { join } from 'node:path'
 import { VError } from '@lvce-editor/verror'
-import { build } from 'esbuild'
+import { bundleJs } from './bundleJs.ts'
 
 interface BundleNodeJsOptions {
   readonly cwd: string
@@ -16,16 +15,11 @@ export const bundleNodeJs = async ({
   external = [],
 }: BundleNodeJsOptions): Promise<void> => {
   try {
-    await build({
-      absWorkingDir: cwd,
-      bundle: true,
-      entryPoints: [join(cwd, from)],
-      external: [...external],
-      format: 'esm',
-      outfile: join(cwd, outFile),
-      platform: 'node',
-      sourcemap: false,
-      target: ['node18'],
+    await bundleJs({
+      cwd,
+      from,
+      outFile,
+      external,
     })
   } catch (error) {
     throw new VError(error, 'Failed to bundle node js')


### PR DESCRIPTION
Use Rollup with Babel TypeScript parsing, CommonJS conversion, and Node resolution for all production bundles. Keep esbuild limited to the development watch workflow.