### PR TITLE
feature: enable recommended virtual dom lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@ import * as config from '@lvce-editor/eslint-config'
 
 export default [
   ...config.default,
+  ...config.recommendedVirtualDom,
   ...config.recommendedActions,
   ...config.recommendedRegex,
   ...config.recommendedTsconfig,
@@ -27,6 +28,49 @@ export default [
     ],
     rules: {
       'jest/no-restricted-jest-methods': 'off',
+    },
+  },
+  {
+    files: [
+      'packages/process-explorer-worker/src/parts/CollapseAll/CollapseAll.ts',
+      'packages/process-explorer-worker/src/parts/Create/Create.ts',
+      'packages/process-explorer-worker/src/parts/DebugProcess/DebugProcess.ts',
+      'packages/process-explorer-worker/src/parts/ExpandAll/ExpandAll.ts',
+      'packages/process-explorer-worker/src/parts/FocusFirst/FocusFirst.ts',
+      'packages/process-explorer-worker/src/parts/FocusIndex/FocusIndex.ts',
+      'packages/process-explorer-worker/src/parts/FocusLast/FocusLast.ts',
+      'packages/process-explorer-worker/src/parts/FocusNext/FocusNext.ts',
+      'packages/process-explorer-worker/src/parts/FocusPrevious/FocusPrevious.ts',
+      'packages/process-explorer-worker/src/parts/GetMenuEntries/GetMenuEntries.ts',
+      'packages/process-explorer-worker/src/parts/HandleArrowLeft/HandleArrowLeft.ts',
+      'packages/process-explorer-worker/src/parts/HandleContextMenu/HandleContextMenu.ts',
+      'packages/process-explorer-worker/src/parts/HandleDoubleClick/HandleDoubleClick.ts',
+      'packages/process-explorer-worker/src/parts/InitializeProcessExplorer/InitializeProcessExplorer.ts',
+      'packages/process-explorer-worker/src/parts/KillProcess/KillProcess.ts',
+      'packages/process-explorer-worker/src/parts/LoadContent/LoadContent.ts',
+      'packages/process-explorer-worker/src/parts/ProcessExplorer/ProcessExplorer.ts',
+      'packages/process-explorer-worker/src/parts/Refresh/Refresh.ts',
+      'packages/process-explorer-worker/src/parts/SetUpdateInterval/SetUpdateInterval.ts',
+      'packages/process-explorer-worker/src/parts/ToggleIndex/ToggleIndex.ts',
+    ],
+    rules: {
+      'virtual-dom/prefer-state-destructuring': 'off',
+    },
+  },
+  {
+    files: [
+      'packages/process-explorer-worker/src/parts/LaunchProcessExplorerNode/LaunchProcessExplorerNode.ts',
+    ],
+    rules: {
+      'virtual-dom/no-object-attribute-values': 'off',
+    },
+  },
+  {
+    files: ['packages/process-explorer-worker/test/**/*.ts'],
+    rules: {
+      'virtual-dom/no-object-attribute-values': 'off',
+      'virtual-dom/prefer-merge-class-names': 'off',
+      'virtual-dom/prefer-state-destructuring': 'off',
     },
   },
 ]

--- a/packages/process-explorer-worker/src/parts/RenderItems/RenderItems.ts
+++ b/packages/process-explorer-worker/src/parts/RenderItems/RenderItems.ts
@@ -1,5 +1,9 @@
 import { ViewletCommand } from '@lvce-editor/constants'
-import { text, VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
+import {
+  mergeClassNames,
+  text,
+  VirtualDomElements,
+} from '@lvce-editor/virtual-dom-worker'
 import type { ProcessExplorerState } from '../ProcessExplorerState/ProcessExplorerState.ts'
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import type { VisibleProcess } from '../VisibleProcess/VisibleProcess.ts'
@@ -8,10 +12,11 @@ import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import * as FormatMemory from '../FormatMemory/FormatMemory.ts'
 import * as ProcessFlag from '../ProcessFlag/ProcessFlag.ts'
+import * as TabIndex from '../TabIndex/TabIndex.ts'
 
 const getRowClassName = (focused: boolean): string => {
   if (focused) {
-    return `${ClassNames.Row} ${ClassNames.RowFocused}`
+    return mergeClassNames(ClassNames.Row, ClassNames.RowFocused)
   }
   return ClassNames.Row
 }
@@ -88,7 +93,6 @@ const getRowDom = (
 ): readonly VirtualDomNode[] => {
   return [
     {
-      ariaDescription: '',
       ariaExpanded: getAriaExpanded(process),
       ariaLevel: process.depth,
       childCount: 3,
@@ -147,27 +151,29 @@ const getErrorSectionDom = (
 }
 
 const hasError = (state: ProcessExplorerState): boolean => {
-  return Boolean(state.errorMessage || state.errorCodeFrame || state.errorStack)
+  const { errorCodeFrame, errorMessage, errorStack } = state
+  return Boolean(errorMessage || errorCodeFrame || errorStack)
 }
 
 const getErrorDom = (
   state: ProcessExplorerState,
 ): readonly VirtualDomNode[] => {
-  const messageDom = getErrorSectionDom(
-    state.errorMessage,
-    VirtualDomElements.Div,
-  )
+  const { errorCodeFrame, errorMessage, errorStack } = state
+  const messageDom = getErrorSectionDom(errorMessage, VirtualDomElements.Div)
   const codeFrameDom = getErrorSectionDom(
-    state.errorCodeFrame,
+    errorCodeFrame,
     VirtualDomElements.Pre,
   )
-  const stackDom = getErrorSectionDom(state.errorStack, VirtualDomElements.Pre)
+  const stackDom = getErrorSectionDom(errorStack, VirtualDomElements.Pre)
   const childCount =
     messageDom.length / 2 + codeFrameDom.length / 2 + stackDom.length / 2
   return [
     {
       childCount: 1,
-      className: `${ClassNames.Viewlet} ${ClassNames.ProcessExplorer}`,
+      className: mergeClassNames(
+        ClassNames.Viewlet,
+        ClassNames.ProcessExplorer,
+      ),
       role: AriaRoles.None,
       type: VirtualDomElements.Div,
     },
@@ -185,16 +191,20 @@ const getErrorDom = (
 const getTableDom = (
   state: ProcessExplorerState,
 ): readonly VirtualDomNode[] => {
+  const { visibleProcesses } = state
   return [
     {
       childCount: 1,
-      className: `${ClassNames.Viewlet} ${ClassNames.ProcessExplorer}`,
+      className: mergeClassNames(
+        ClassNames.Viewlet,
+        ClassNames.ProcessExplorer,
+      ),
       role: AriaRoles.None,
       type: VirtualDomElements.Div,
     },
     {
       ariaLabel: 'Process Explorer',
-      ariaRowCount: state.visibleProcesses.length + 1,
+      ariaRowCount: visibleProcesses.length + 1,
       childCount: 2,
       className: ClassNames.Table,
       onBlur: DomEventListenerFunctions.HandleBlur,
@@ -204,7 +214,7 @@ const getTableDom = (
       onFocus: DomEventListenerFunctions.HandleFocus,
       onPointerDown: DomEventListenerFunctions.HandlePointerDown,
       role: AriaRoles.Grid,
-      tabIndex: 0,
+      tabIndex: TabIndex.Focusable,
       type: VirtualDomElements.Table,
     },
     ...getHeaderDom(),
@@ -213,7 +223,8 @@ const getTableDom = (
 }
 
 const getDom = (state: ProcessExplorerState): readonly VirtualDomNode[] => {
-  if (state.initial) {
+  const { initial } = state
+  if (initial) {
     return []
   }
   if (hasError(state)) {

--- a/packages/process-explorer-worker/src/parts/TabIndex/TabIndex.ts
+++ b/packages/process-explorer-worker/src/parts/TabIndex/TabIndex.ts
@@ -1,0 +1,1 @@
+export const Focusable = 0


### PR DESCRIPTION
Enable the shared recommended virtual DOM ESLint configuration and fix the renderer findings for ARIA metadata, class-name composition, state access, and focusability. Non-render state modules and literal test fixtures retain narrowly scoped rule exceptions.\n\nValidated with lint/knip, type-check, build, and both unit-test projects.