### PR TITLE
feature: send message port to main process

### DIFF
--- a/packages/process-explorer-worker/src/parts/LaunchProcessExplorerElectron/LaunchProcessExplorerElectron.ts
+++ b/packages/process-explorer-worker/src/parts/LaunchProcessExplorerElectron/LaunchProcessExplorerElectron.ts
@@ -1,13 +1,13 @@
 import type { Rpc } from '@lvce-editor/rpc'
 import { LazyTransferMessagePortRpcParent } from '@lvce-editor/rpc'
 import { VError } from '@lvce-editor/verror'
-import * as SendMessagePortToProcessExplorer from '../SendMessagePortToProcessExplorer/SendMessagePortToProcessExplorer.ts'
+import * as SendMessagePortToMainProcess from '../SendMessagePortToMainProcess/SendMessagePortToMainProcess.ts'
 
 export const launchProcessExplorerElectron = async (): Promise<Rpc> => {
   try {
     const rpc = await LazyTransferMessagePortRpcParent.create({
       commandMap: {},
-      send: SendMessagePortToProcessExplorer.sendMessagePortToProcessExplorer,
+      send: SendMessagePortToMainProcess.sendMessagePortToMainProcess,
     })
     return rpc
   } catch (error) {

--- a/packages/process-explorer-worker/src/parts/SendMessagePortToMainProcess/SendMessagePortToMainProcess.ts
+++ b/packages/process-explorer-worker/src/parts/SendMessagePortToMainProcess/SendMessagePortToMainProcess.ts
@@ -1,0 +1,13 @@
+import { RpcId } from '@lvce-editor/constants'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+
+export const sendMessagePortToMainProcess = async (
+  port: MessagePort,
+): Promise<void> => {
+  await RendererWorker.invokeAndTransfer(
+    'SendMessagePortToMainProcess.sendMessagePortToMainProcess',
+    port,
+    'HandleElectronMessagePort.handleElectronMessagePort',
+    RpcId.ProcessExplorerRenderer,
+  )
+}

--- a/packages/process-explorer-worker/src/parts/SendMessagePortToProcessExplorer/SendMessagePortToProcessExplorer.ts
+++ b/packages/process-explorer-worker/src/parts/SendMessagePortToProcessExplorer/SendMessagePortToProcessExplorer.ts
@@ -1,7 +1,0 @@
-import { RendererWorker } from '@lvce-editor/rpc-registry'
-
-export const sendMessagePortToProcessExplorer = async (
-  port: MessagePort,
-): Promise<void> => {
-  await RendererWorker.sendMessagePortToProcessExplorer(port)
-}

--- a/packages/process-explorer-worker/test/LaunchProcessExplorerElectron.test.ts
+++ b/packages/process-explorer-worker/test/LaunchProcessExplorerElectron.test.ts
@@ -1,7 +1,7 @@
 import { expect, jest, test } from '@jest/globals'
 
-const sendMessagePortToProcessExplorer = jest.fn(
-  async (_port: MessagePort) => undefined,
+const invokeAndTransfer = jest.fn(
+  async (..._args: readonly unknown[]) => undefined,
 )
 const mockRpc = {
   invoke: jest.fn(),
@@ -26,7 +26,7 @@ jest.unstable_mockModule('@lvce-editor/rpc', () => ({
 
 jest.unstable_mockModule('@lvce-editor/rpc-registry', () => ({
   RendererWorker: {
-    sendMessagePortToProcessExplorer,
+    invokeAndTransfer,
   },
 }))
 
@@ -42,7 +42,10 @@ test('launchProcessExplorerElectron - creates rpc and sends message port', async
     commandMap: {},
     send: expect.any(Function),
   })
-  expect(sendMessagePortToProcessExplorer).toHaveBeenCalledWith(
+  expect(invokeAndTransfer).toHaveBeenCalledWith(
+    'SendMessagePortToMainProcess.sendMessagePortToMainProcess',
     expect.anything(),
+    'HandleElectronMessagePort.handleElectronMessagePort',
+    33,
   )
 })


### PR DESCRIPTION
Uses renderer-worker's generic main-process port transfer for Electron process data, removing the specialized process-explorer-to-shared-process forwarding path.