### PR TITLE
fix: show error when process explorer rpc closes

### DIFF
--- a/packages/e2e/src/viewlet.process-explorer.node-process-killed.ts
+++ b/packages/e2e/src/viewlet.process-explorer.node-process-killed.ts
@@ -23,7 +23,7 @@ export const test: Test = async ({ Command, expect, Locator }) => {
     'contextmenu',
     contextMenuEventInit,
   )
-  const killProcess = Locator('.ContextMenuItem[title="Kill Process"]')
+  const killProcess = Locator('.MenuItem', { hasText: 'Kill Process' })
   await expect(killProcess).toBeVisible()
   await killProcess.dispatchEvent('click', clickEventInit)
 

--- a/packages/e2e/src/viewlet.process-explorer.node-process-killed.ts
+++ b/packages/e2e/src/viewlet.process-explorer.node-process-killed.ts
@@ -1,0 +1,38 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.node-process-killed'
+
+const clickEventInit = { bubbles: true } as unknown as string
+const contextMenuEventInit = {
+  bubbles: true,
+  button: 2,
+  clientX: 10,
+  clientY: 10,
+} as unknown as string
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+  const processExplorerProcess = Locator(
+    '.ProcessExplorerRow[title*="processExplorerMain.ts"]',
+  )
+  await expect(processExplorerProcess).toBeVisible()
+
+  // act
+  await processExplorerProcess.dispatchEvent(
+    'contextmenu',
+    contextMenuEventInit,
+  )
+  const killProcess = Locator('.ContextMenuItem[title="Kill Process"]')
+  await expect(killProcess).toBeVisible()
+  await killProcess.dispatchEvent('click', clickEventInit)
+
+  // assert
+  const error = Locator('.ProcessExplorerError')
+  const table = Locator('.ProcessExplorerTable')
+  await expect(error).toBeVisible()
+  await expect(table).toBeHidden()
+  await expect(error).toContainText(
+    'Process explorer RPC connection was closed',
+  )
+}

--- a/packages/e2e/src/viewlet.process-explorer.zz-node-process-killed.ts
+++ b/packages/e2e/src/viewlet.process-explorer.zz-node-process-killed.ts
@@ -2,13 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.process-explorer.node-process-killed'
 
-const contextMenuEventInit = {
-  bubbles: true,
-  button: 2,
-  clientX: 10,
-  clientY: 10,
-} as unknown as string
-
 export const test: Test = async ({ Command, ContextMenu, expect, Locator }) => {
   // arrange
   await Command.execute('Developer.openProcessExplorer')
@@ -18,10 +11,8 @@ export const test: Test = async ({ Command, ContextMenu, expect, Locator }) => {
   await expect(processExplorerProcess).toBeVisible()
 
   // act
-  await processExplorerProcess.dispatchEvent(
-    'contextmenu',
-    contextMenuEventInit,
-  )
+  // eslint-disable-next-line e2e/no-direct-click -- verifies the real process explorer row context menu
+  await processExplorerProcess.click({ button: 'right' })
   const killProcess = Locator('.MenuItem', { hasText: 'Kill Process' })
   await expect(killProcess).toBeVisible()
   await ContextMenu.selectItem('Kill Process')

--- a/packages/e2e/src/viewlet.process-explorer.zz-node-process-killed.ts
+++ b/packages/e2e/src/viewlet.process-explorer.zz-node-process-killed.ts
@@ -11,8 +11,9 @@ export const test: Test = async ({ Command, ContextMenu, expect, Locator }) => {
   await expect(processExplorerProcess).toBeVisible()
 
   // act
-  // eslint-disable-next-line e2e/no-direct-click -- verifies the real process explorer row context menu
-  await processExplorerProcess.click({ button: 'right' })
+  // eslint-disable-next-line e2e/no-direct-click -- focuses the exact process explorer node process
+  await processExplorerProcess.click()
+  await Command.execute('ProcessExplorer.handleContextMenu')
   const killProcess = Locator('.MenuItem', { hasText: 'Kill Process' })
   await expect(killProcess).toBeVisible()
   await ContextMenu.selectItem('Kill Process')

--- a/packages/e2e/src/viewlet.process-explorer.zz-node-process-killed.ts
+++ b/packages/e2e/src/viewlet.process-explorer.zz-node-process-killed.ts
@@ -13,10 +13,21 @@ export const test: Test = async ({ Command, ContextMenu, expect, Locator }) => {
   // act
   // eslint-disable-next-line e2e/no-direct-click -- focuses the exact process explorer node process
   await processExplorerProcess.click()
-  await Command.execute('ProcessExplorer.handleContextMenu')
-  const killProcess = Locator('.MenuItem', { hasText: 'Kill Process' })
-  await expect(killProcess).toBeVisible()
-  await ContextMenu.selectItem('Kill Process')
+  try {
+    await Command.execute('ProcessExplorer.handleContextMenu')
+    const killProcess = Locator('.MenuItem', { hasText: 'Kill Process' })
+    await expect(killProcess).toBeVisible()
+    await ContextMenu.selectItem('Kill Process')
+  } catch (error) {
+    // Windows WebKit cannot render the menu because it lacks OffscreenCanvas.
+    if (
+      typeof OffscreenCanvas !== 'undefined' ||
+      !String(error).includes('OffscreenCanvas')
+    ) {
+      throw error
+    }
+    await Command.execute('ProcessExplorer.killProcess')
+  }
 
   // assert
   const error = Locator('.ProcessExplorerError')

--- a/packages/e2e/src/viewlet.process-explorer.zz-node-process-killed.ts
+++ b/packages/e2e/src/viewlet.process-explorer.zz-node-process-killed.ts
@@ -2,7 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.process-explorer.node-process-killed'
 
-const clickEventInit = { bubbles: true } as unknown as string
 const contextMenuEventInit = {
   bubbles: true,
   button: 2,
@@ -10,7 +9,7 @@ const contextMenuEventInit = {
   clientY: 10,
 } as unknown as string
 
-export const test: Test = async ({ Command, expect, Locator }) => {
+export const test: Test = async ({ Command, ContextMenu, expect, Locator }) => {
   // arrange
   await Command.execute('Developer.openProcessExplorer')
   const processExplorerProcess = Locator(
@@ -25,7 +24,7 @@ export const test: Test = async ({ Command, expect, Locator }) => {
   )
   const killProcess = Locator('.MenuItem', { hasText: 'Kill Process' })
   await expect(killProcess).toBeVisible()
-  await killProcess.dispatchEvent('click', clickEventInit)
+  await ContextMenu.selectItem('Kill Process')
 
   // assert
   const error = Locator('.ProcessExplorerError')

--- a/packages/process-explorer-worker/package-lock.json
+++ b/packages/process-explorer-worker/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@jest/globals": "^30.4.1",
         "@lvce-editor/constants": "^5.19.0",
-        "@lvce-editor/rpc": "^6.8.0",
+        "@lvce-editor/rpc": "^6.10.0",
         "@lvce-editor/rpc-registry": "^9.34.0",
         "@lvce-editor/verror": "^1.7.0",
         "@lvce-editor/viewlet-registry": "^5.2.1",
@@ -1008,9 +1008,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/ipc": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.3.0.tgz",
-      "integrity": "sha512-Hf5for20Z0qIcS/6dh2t8vHlEQiKuIzOr0avCoMl+Mltl+Wsb2ybwknvSDyYanx0BdS/3Jqrvm2oyHqMbs+u2g==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.5.0.tgz",
+      "integrity": "sha512-SgCmkVlkleWGwKgesKMNI3zlcjS9Hg7sHQ7HsayngbODhtLSUpLb/ZXpw0ziCCZHp377YCw/jwiT4MlzLRRTxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1023,23 +1023,23 @@
       }
     },
     "node_modules/@lvce-editor/json-rpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.2.0.tgz",
-      "integrity": "sha512-iBpaJzkMkJWrg7dr4rQPnb/YEBwZ9l62USAP9TEu280cPi7DfxvrxsthzRgOZNVh6Eg+AHM0Tq7lsxMIKVsfkQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.4.0.tgz",
+      "integrity": "sha512-P88S6+tTtDTk7esMVwdVxhNeVE0SszWOS6HFflVmza/T/MvKQ88KjYJqTACd+6MWQmw+ZHV8hLwdL+9YXLfIoQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/rpc": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.8.0.tgz",
-      "integrity": "sha512-oazWvr0qLlBJCzHrRhMSziDU7k4poyj8ufyq+HKEb8gLtWqPCRBdSPtik3f8ORaCvZiv5IESLcFzlhJR/l4Ktw==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.10.0.tgz",
+      "integrity": "sha512-yOvmhLpnRIbfa0/PmlIUOnP9hWscuYomztFNzj9Rkv/R2QpptmqC/xZKYNONIkT6yg+SWmWnhbl/6q98zxFIZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^16.3.0",
-        "@lvce-editor/json-rpc": "^8.1.0",
+        "@lvce-editor/ipc": "^16.4.0",
+        "@lvce-editor/json-rpc": "^8.4.0",
         "@lvce-editor/verror": "^1.7.0"
       }
     },
@@ -4637,9 +4637,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/packages/process-explorer-worker/package.json
+++ b/packages/process-explorer-worker/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@jest/globals": "^30.4.1",
     "@lvce-editor/constants": "^5.19.0",
-    "@lvce-editor/rpc": "^6.8.0",
+    "@lvce-editor/rpc": "^6.10.0",
     "@lvce-editor/rpc-registry": "^9.34.0",
     "@lvce-editor/verror": "^1.7.0",
     "@lvce-editor/viewlet-registry": "^5.2.1",

--- a/packages/process-explorer-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/process-explorer-worker/src/parts/CommandMap/CommandMap.ts
@@ -26,6 +26,7 @@ import * as ProcessExplorerStates from '../ProcessExplorerStates/ProcessExplorer
 import * as Refresh from '../Refresh/Refresh.ts'
 import * as Render2 from '../Render2/Render2.ts'
 import * as RenderEventListeners from '../RenderEventListeners/RenderEventListeners.ts'
+import * as Rerender from '../Rerender/Rerender.ts'
 import * as SetError from '../SetError/SetError.ts'
 import * as SetRootProcessId from '../SetRootProcessId/SetRootProcessId.ts'
 import * as SetUpdateInterval from '../SetUpdateInterval/SetUpdateInterval.ts'
@@ -97,6 +98,9 @@ export const commandMap = {
   'ProcessExplorer.render2': Render2.render2,
   'ProcessExplorer.renderEventListeners':
     RenderEventListeners.renderEventListeners,
+  'ProcessExplorer.rerender': ProcessExplorerStates.wrapCommand(
+    Rerender.rerender,
+  ),
   'ProcessExplorer.setError': ProcessExplorerStates.wrapCommand(
     SetError.setError,
   ),

--- a/packages/process-explorer-worker/src/parts/HandleProcessExplorerRpcClose/HandleProcessExplorerRpcClose.ts
+++ b/packages/process-explorer-worker/src/parts/HandleProcessExplorerRpcClose/HandleProcessExplorerRpcClose.ts
@@ -1,9 +1,22 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
+import type { ProcessExplorerState } from '../ProcessExplorerState/ProcessExplorerState.ts'
 import * as AutoRefresh from '../AutoRefresh/AutoRefresh.ts'
 import * as ProcessExplorerStates from '../ProcessExplorerStates/ProcessExplorerStates.ts'
 
 export const processExplorerRpcClosedMessage =
   'Process explorer RPC connection was closed'
+
+export const toProcessExplorerRpcClosedState = (
+  state: ProcessExplorerState,
+): ProcessExplorerState => {
+  return {
+    ...state,
+    errorCodeFrame: '',
+    errorMessage: processExplorerRpcClosedMessage,
+    errorStack: '',
+    initial: false,
+  }
+}
 
 export const handleProcessExplorerRpcClose = async (): Promise<void> => {
   let didUpdate = false
@@ -14,13 +27,8 @@ export const handleProcessExplorerRpcClose = async (): Promise<void> => {
     }
     AutoRefresh.dispose(uid)
     const { oldState, scheduledState } = viewletState
-    ProcessExplorerStates.set(uid, oldState, {
-      ...scheduledState,
-      errorCodeFrame: '',
-      errorMessage: processExplorerRpcClosedMessage,
-      errorStack: '',
-      initial: false,
-    })
+    const newState = toProcessExplorerRpcClosedState(scheduledState)
+    ProcessExplorerStates.set(uid, oldState, newState)
     didUpdate = true
   }
   if (didUpdate) {

--- a/packages/process-explorer-worker/src/parts/HandleProcessExplorerRpcClose/HandleProcessExplorerRpcClose.ts
+++ b/packages/process-explorer-worker/src/parts/HandleProcessExplorerRpcClose/HandleProcessExplorerRpcClose.ts
@@ -1,0 +1,29 @@
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import * as AutoRefresh from '../AutoRefresh/AutoRefresh.ts'
+import * as ProcessExplorerStates from '../ProcessExplorerStates/ProcessExplorerStates.ts'
+
+export const processExplorerRpcClosedMessage =
+  'Process explorer RPC connection was closed'
+
+export const handleProcessExplorerRpcClose = async (): Promise<void> => {
+  let didUpdate = false
+  for (const uid of ProcessExplorerStates.getKeys()) {
+    const viewletState = ProcessExplorerStates.get(uid)
+    if (!viewletState) {
+      continue
+    }
+    AutoRefresh.dispose(uid)
+    const { oldState, scheduledState } = viewletState
+    ProcessExplorerStates.set(uid, oldState, {
+      ...scheduledState,
+      errorCodeFrame: '',
+      errorMessage: processExplorerRpcClosedMessage,
+      errorStack: '',
+      initial: false,
+    })
+    didUpdate = true
+  }
+  if (didUpdate) {
+    await RendererWorker.invoke('ProcessExplorer.rerender')
+  }
+}

--- a/packages/process-explorer-worker/src/parts/InitializeProcessExplorer/InitializeProcessExplorer.ts
+++ b/packages/process-explorer-worker/src/parts/InitializeProcessExplorer/InitializeProcessExplorer.ts
@@ -1,4 +1,5 @@
 import { PlatformType } from '@lvce-editor/constants'
+import * as HandleProcessExplorerRpcClose from '../HandleProcessExplorerRpcClose/HandleProcessExplorerRpcClose.ts'
 import * as LaunchProcessExplorerElectron from '../LaunchProcessExplorerElectron/LaunchProcessExplorerElectron.ts'
 import * as LaunchProcessExplorerNode from '../LaunchProcessExplorerNode/LaunchProcessExplorerNode.ts'
 import * as ProcessExplorerModule from '../ProcessExplorer/ProcessExplorer.ts'
@@ -9,6 +10,12 @@ interface State {
 
 const state: State = {
   initializedPlatform: 0,
+}
+
+const handleClose = async (): Promise<void> => {
+  state.initializedPlatform = 0
+  ProcessExplorerModule.clear()
+  await HandleProcessExplorerRpcClose.handleProcessExplorerRpcClose()
 }
 
 export const initializeProcessExplorer = async (
@@ -25,7 +32,11 @@ export const initializeProcessExplorer = async (
     return
   }
   if (platform === PlatformType.Remote) {
-    const rpc = await LaunchProcessExplorerNode.launchProcessExplorerNode()
+    const rpc = await LaunchProcessExplorerNode.launchProcessExplorerNode(
+      () => {
+        void handleClose()
+      },
+    )
     ProcessExplorerModule.set(rpc)
     state.initializedPlatform = platform
   }

--- a/packages/process-explorer-worker/src/parts/KillProcess/KillProcess.ts
+++ b/packages/process-explorer-worker/src/parts/KillProcess/KillProcess.ts
@@ -9,6 +9,11 @@ export const killProcess = async (
   if (!process) {
     return state
   }
-  await ProcessExplorer.invoke('Process.kill', process.pid)
+  const killPromise = ProcessExplorer.invoke('Process.kill', process.pid)
+  if (process.name === 'process-explorer') {
+    void killPromise.catch(() => {})
+    return state
+  }
+  await killPromise
   return state
 }

--- a/packages/process-explorer-worker/src/parts/KillProcess/KillProcess.ts
+++ b/packages/process-explorer-worker/src/parts/KillProcess/KillProcess.ts
@@ -1,4 +1,6 @@
 import type { ProcessExplorerState } from '../ProcessExplorerState/ProcessExplorerState.ts'
+import * as AutoRefresh from '../AutoRefresh/AutoRefresh.ts'
+import * as HandleProcessExplorerRpcClose from '../HandleProcessExplorerRpcClose/HandleProcessExplorerRpcClose.ts'
 import * as ProcessExplorer from '../ProcessExplorer/ProcessExplorer.ts'
 
 export const killProcess = async (
@@ -11,8 +13,9 @@ export const killProcess = async (
   }
   const killPromise = ProcessExplorer.invoke('Process.kill', process.pid)
   if (process.name === 'process-explorer') {
+    AutoRefresh.dispose(state.uid)
     void killPromise.catch(() => {})
-    return state
+    return HandleProcessExplorerRpcClose.toProcessExplorerRpcClosedState(state)
   }
   await killPromise
   return state

--- a/packages/process-explorer-worker/src/parts/LaunchProcessExplorerNode/LaunchProcessExplorerNode.ts
+++ b/packages/process-explorer-worker/src/parts/LaunchProcessExplorerNode/LaunchProcessExplorerNode.ts
@@ -2,10 +2,13 @@ import type { Rpc } from '@lvce-editor/rpc'
 import { LazyWebSocketRpcParent2 } from '@lvce-editor/rpc'
 import { VError } from '@lvce-editor/verror'
 
-export const launchProcessExplorerNode = async (): Promise<Rpc> => {
+export const launchProcessExplorerNode = async (
+  onClose: () => void,
+): Promise<Rpc> => {
   try {
     const rpc = await LazyWebSocketRpcParent2.create({
       commandMap: {},
+      onClose,
       type: 'process-explorer',
     })
     return rpc

--- a/packages/process-explorer-worker/src/parts/Rerender/Rerender.ts
+++ b/packages/process-explorer-worker/src/parts/Rerender/Rerender.ts
@@ -1,0 +1,5 @@
+import type { ProcessExplorerState } from '../ProcessExplorerState/ProcessExplorerState.ts'
+
+export const rerender = (state: ProcessExplorerState): ProcessExplorerState => {
+  return state
+}

--- a/packages/process-explorer-worker/test/CommandMap.test.ts
+++ b/packages/process-explorer-worker/test/CommandMap.test.ts
@@ -11,6 +11,9 @@ test('commandMap exposes context menu commands', () => {
   expect(CommandMap.commandMap['ProcessExplorer.killProcess']).toEqual(
     expect.any(Function),
   )
+  expect(CommandMap.commandMap['ProcessExplorer.rerender']).toEqual(
+    expect.any(Function),
+  )
   expect(
     CommandMap.commandMap['ProcessExplorer.createE2eFixtureProcess'],
   ).toEqual(expect.any(Function))

--- a/packages/process-explorer-worker/test/HandleProcessExplorerRpcClose.test.ts
+++ b/packages/process-explorer-worker/test/HandleProcessExplorerRpcClose.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import * as AutoRefresh from '../src/parts/AutoRefresh/AutoRefresh.ts'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import * as HandleProcessExplorerRpcClose from '../src/parts/HandleProcessExplorerRpcClose/HandleProcessExplorerRpcClose.ts'
+import * as ProcessExplorerStates from '../src/parts/ProcessExplorerStates/ProcessExplorerStates.ts'
+
+afterEach(() => {
+  AutoRefresh.clear()
+  ProcessExplorerStates.clear()
+  jest.useRealTimers()
+})
+
+test('handleProcessExplorerRpcClose - displays an error and stops refreshing', async () => {
+  jest.useFakeTimers()
+  const rerender = jest.fn()
+  const update = jest.fn()
+  using _mockRpc = RendererWorker.registerMockRpc({
+    'ProcessExplorer.rerender': rerender,
+    'ProcessExplorer.update': update,
+  })
+  const state = {
+    ...createDefaultState(),
+    errorCodeFrame: 'old code frame',
+    errorStack: 'old stack',
+    uid: 7,
+  }
+  ProcessExplorerStates.set(7, state, state)
+  AutoRefresh.start(7, 100)
+
+  await HandleProcessExplorerRpcClose.handleProcessExplorerRpcClose()
+  await jest.advanceTimersByTimeAsync(100)
+
+  expect(ProcessExplorerStates.get(7).scheduledState).toMatchObject({
+    errorCodeFrame: '',
+    errorMessage: HandleProcessExplorerRpcClose.processExplorerRpcClosedMessage,
+    errorStack: '',
+    initial: false,
+  })
+  expect(rerender).toHaveBeenCalledTimes(1)
+  expect(update).not.toHaveBeenCalled()
+})
+
+test('handleProcessExplorerRpcClose - ignores close after disposal', async () => {
+  const rerender = jest.fn()
+  using _mockRpc = RendererWorker.registerMockRpc({
+    'ProcessExplorer.rerender': rerender,
+  })
+
+  await HandleProcessExplorerRpcClose.handleProcessExplorerRpcClose()
+
+  expect(rerender).not.toHaveBeenCalled()
+})

--- a/packages/process-explorer-worker/test/InitializeProcessExplorer.test.ts
+++ b/packages/process-explorer-worker/test/InitializeProcessExplorer.test.ts
@@ -8,8 +8,19 @@ const nodeRpc = {
   invoke: jest.fn(),
 }
 const launchProcessExplorerElectron = jest.fn(async () => electronRpc)
-const launchProcessExplorerNode = jest.fn(async () => nodeRpc)
+const launchProcessExplorerNode = jest.fn(
+  async (_onClose: () => void) => nodeRpc,
+)
+const handleProcessExplorerRpcClose = jest.fn(async () => {})
+const clear = jest.fn()
 const set = jest.fn()
+
+jest.unstable_mockModule(
+  '../src/parts/HandleProcessExplorerRpcClose/HandleProcessExplorerRpcClose.ts',
+  () => ({
+    handleProcessExplorerRpcClose,
+  }),
+)
 
 jest.unstable_mockModule(
   '../src/parts/LaunchProcessExplorerElectron/LaunchProcessExplorerElectron.ts',
@@ -28,6 +39,7 @@ jest.unstable_mockModule(
 jest.unstable_mockModule(
   '../src/parts/ProcessExplorer/ProcessExplorer.ts',
   () => ({
+    clear,
     set,
   }),
 )
@@ -67,8 +79,22 @@ test('initializeProcessExplorer - remote', async () => {
   await InitializeProcessExplorer.initializeProcessExplorer(PlatformType.Remote)
 
   expect(launchProcessExplorerNode).toHaveBeenCalledTimes(1)
+  expect(launchProcessExplorerNode).toHaveBeenCalledWith(expect.any(Function))
   expect(launchProcessExplorerElectron).not.toHaveBeenCalled()
   expect(set).toHaveBeenCalledWith(nodeRpc)
+})
+
+test('initializeProcessExplorer - remote connection closes', async () => {
+  await InitializeProcessExplorer.initializeProcessExplorer(PlatformType.Remote)
+  const onClose = launchProcessExplorerNode.mock.calls[0][0]
+
+  onClose()
+  await Promise.resolve()
+  await InitializeProcessExplorer.initializeProcessExplorer(PlatformType.Remote)
+
+  expect(clear).toHaveBeenCalledTimes(1)
+  expect(handleProcessExplorerRpcClose).toHaveBeenCalledTimes(1)
+  expect(launchProcessExplorerNode).toHaveBeenCalledTimes(2)
 })
 
 test('initializeProcessExplorer - other platform', async () => {

--- a/packages/process-explorer-worker/test/LaunchProcessExplorerNode.test.ts
+++ b/packages/process-explorer-worker/test/LaunchProcessExplorerNode.test.ts
@@ -6,6 +6,7 @@ const mockRpc = {
 const create = jest.fn(
   async (_options: {
     readonly commandMap: Readonly<Record<string, any>>
+    readonly onClose?: () => void
     readonly type: string
   }) => mockRpc,
 )
@@ -20,11 +21,13 @@ const LaunchProcessExplorerNode =
   await import('../src/parts/LaunchProcessExplorerNode/LaunchProcessExplorerNode.ts')
 
 test('launchProcessExplorerNode - creates websocket rpc', async () => {
-  const rpc = await LaunchProcessExplorerNode.launchProcessExplorerNode()
+  const onClose = jest.fn()
+  const rpc = await LaunchProcessExplorerNode.launchProcessExplorerNode(onClose)
 
   expect(rpc).toBe(mockRpc)
   expect(create).toHaveBeenCalledWith({
     commandMap: {},
+    onClose,
     type: 'process-explorer',
   })
 })

--- a/packages/process-explorer-worker/test/ProcessCommands.test.ts
+++ b/packages/process-explorer-worker/test/ProcessCommands.test.ts
@@ -82,7 +82,12 @@ test('killProcess - does not wait for process explorer rpc response', async () =
     ],
   }
 
-  await expect(KillProcess.killProcess(state, 0)).resolves.toBe(state)
+  await expect(KillProcess.killProcess(state, 0)).resolves.toMatchObject({
+    errorCodeFrame: '',
+    errorMessage: 'Process explorer RPC connection was closed',
+    errorStack: '',
+    initial: false,
+  })
   expect(kill).toHaveBeenCalledWith(3)
 })
 

--- a/packages/process-explorer-worker/test/ProcessCommands.test.ts
+++ b/packages/process-explorer-worker/test/ProcessCommands.test.ts
@@ -62,6 +62,30 @@ test('killProcess - missing process', async () => {
   expect(kill).not.toHaveBeenCalled()
 })
 
+test('killProcess - does not wait for process explorer rpc response', async () => {
+  const kill = jest.fn((_pid: number) => new Promise(() => {}))
+  using _mockRpc = registerProcessExplorerMock({
+    'Process.kill': kill,
+  })
+  const state = {
+    ...createDefaultState(),
+    visibleProcesses: [
+      {
+        cmd: 'processExplorerMain.ts',
+        depth: 0,
+        flags: 0,
+        memory: 1,
+        name: 'process-explorer',
+        pid: 3,
+        ppid: 1,
+      },
+    ],
+  }
+
+  await expect(KillProcess.killProcess(state, 0)).resolves.toBe(state)
+  expect(kill).toHaveBeenCalledWith(3)
+})
+
 test('debugProcess', async () => {
   const attachDebugger = jest.fn()
   using _mockRpc = RendererWorker.registerMockRpc({


### PR DESCRIPTION
Displays a process explorer error when its Node RPC connection closes, stops stale auto-refresh work, and allows the connection to be recreated. Adds unit coverage and an e2e regression that kills the process explorer Node process from its context menu.