### PR TITLE
feature: add process explorer e2e coverage

### DIFF
--- a/packages/e2e/src/viewlet.process-explorer.accessibility-container-role.ts
+++ b/packages/e2e/src/viewlet.process-explorer.accessibility-container-role.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.accessibility-container-role'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+
+  // assert
+  const processExplorer = Locator('.ProcessExplorer')
+  await expect(processExplorer).toBeVisible()
+  await expect(processExplorer).toHaveAttribute('role', 'none')
+}

--- a/packages/e2e/src/viewlet.process-explorer.accessibility-grid-label.ts
+++ b/packages/e2e/src/viewlet.process-explorer.accessibility-grid-label.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.accessibility-grid-label'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+
+  // assert
+  const grid = Locator('.ProcessExplorerTable')
+  await expect(grid).toBeVisible()
+  await expect(grid).toHaveAttribute('aria-label', 'Process Explorer')
+}

--- a/packages/e2e/src/viewlet.process-explorer.accessibility-grid-tab-index.ts
+++ b/packages/e2e/src/viewlet.process-explorer.accessibility-grid-tab-index.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.accessibility-grid-tab-index'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+
+  // assert
+  const grid = Locator('.ProcessExplorerTable')
+  await expect(grid).toBeVisible()
+  await expect(grid).toHaveAttribute('tabindex', '0')
+}

--- a/packages/e2e/src/viewlet.process-explorer.accessibility-grid.ts
+++ b/packages/e2e/src/viewlet.process-explorer.accessibility-grid.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.accessibility-grid'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+
+  // assert
+  const grid = Locator('table.ProcessExplorerTable')
+  await expect(grid).toBeVisible()
+  await expect(grid).toHaveAttribute('role', 'grid')
+}

--- a/packages/e2e/src/viewlet.process-explorer.accessibility-header-cells.ts
+++ b/packages/e2e/src/viewlet.process-explorer.accessibility-header-cells.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.accessibility-header-cells'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+
+  // assert
+  const headerCells = Locator('th.ProcessExplorerHeaderCell')
+  await expect(headerCells).toHaveCount(3)
+}

--- a/packages/e2e/src/viewlet.process-explorer.accessibility-header-row.ts
+++ b/packages/e2e/src/viewlet.process-explorer.accessibility-header-row.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.accessibility-header-row'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+
+  // assert
+  const headerRow = Locator('.ProcessExplorerTableHead > tr.ProcessExplorerRow')
+  await expect(headerRow).toBeVisible()
+  await expect(headerRow).toHaveAttribute('role', 'row')
+}

--- a/packages/e2e/src/viewlet.process-explorer.accessibility-memory-cell.ts
+++ b/packages/e2e/src/viewlet.process-explorer.accessibility-memory-cell.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.accessibility-memory-cell'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+
+  // assert
+  const memoryCell = Locator(
+    '.ProcessExplorerRow[data-index="0"] > td.ProcessExplorerCell',
+  ).nth(2)
+  await expect(memoryCell).toBeVisible()
+  await expect(memoryCell).toHaveAttribute('role', 'gridcell')
+  await expect(memoryCell).toHaveAttribute('data-index', '0')
+}

--- a/packages/e2e/src/viewlet.process-explorer.accessibility-name-cell.ts
+++ b/packages/e2e/src/viewlet.process-explorer.accessibility-name-cell.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.accessibility-name-cell'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+
+  // assert
+  const nameCell = Locator('td.ProcessExplorerNameCell[data-index="0"]')
+  await expect(nameCell).toBeVisible()
+  await expect(nameCell).toHaveAttribute('role', 'gridcell')
+  await expect(nameCell).toHaveAttribute('tabindex', '-1')
+}

--- a/packages/e2e/src/viewlet.process-explorer.accessibility-pid-cell.ts
+++ b/packages/e2e/src/viewlet.process-explorer.accessibility-pid-cell.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.accessibility-pid-cell'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+
+  // assert
+  const pidCell = Locator(
+    '.ProcessExplorerRow[data-index="0"] > td.ProcessExplorerCell',
+  ).nth(1)
+  await expect(pidCell).toBeVisible()
+  await expect(pidCell).toHaveAttribute('role', 'gridcell')
+  await expect(pidCell).toHaveAttribute('data-index', '0')
+}

--- a/packages/e2e/src/viewlet.process-explorer.accessibility-process-row.ts
+++ b/packages/e2e/src/viewlet.process-explorer.accessibility-process-row.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.accessibility-process-row'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+
+  // assert
+  const firstRow = Locator(
+    '.ProcessExplorerTableBody > tr.ProcessExplorerRow[data-index="0"]',
+  )
+  await expect(firstRow).toBeVisible()
+  await expect(firstRow).toHaveAttribute('role', 'row')
+  await expect(firstRow).toHaveAttribute('aria-level', '1')
+}

--- a/packages/e2e/src/viewlet.process-explorer.accessibility-row-count.ts
+++ b/packages/e2e/src/viewlet.process-explorer.accessibility-row-count.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.accessibility-row-count'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+
+  // assert
+  const gridWithRowCount = Locator('.ProcessExplorerTable[aria-rowcount]')
+  await expect(gridWithRowCount).toBeVisible()
+}

--- a/packages/e2e/src/viewlet.process-explorer.accessibility-table-body.ts
+++ b/packages/e2e/src/viewlet.process-explorer.accessibility-table-body.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.accessibility-table-body'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+
+  // assert
+  const tableBody = Locator('tbody.ProcessExplorerTableBody')
+  await expect(tableBody).toBeVisible()
+  await expect(tableBody).toHaveAttribute('role', 'rowgroup')
+}

--- a/packages/e2e/src/viewlet.process-explorer.accessibility-table-head.ts
+++ b/packages/e2e/src/viewlet.process-explorer.accessibility-table-head.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.accessibility-table-head'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+
+  // assert
+  const tableHead = Locator('thead.ProcessExplorerTableHead')
+  await expect(tableHead).toBeVisible()
+  await expect(tableHead).toHaveAttribute('role', 'rowgroup')
+}

--- a/packages/e2e/src/viewlet.process-explorer.focus-clicked-index.ts
+++ b/packages/e2e/src/viewlet.process-explorer.focus-clicked-index.ts
@@ -1,0 +1,25 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.focus-clicked-index'
+
+const defaultUpdateInterval = 1000
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+  await Command.execute('ProcessExplorer.setUpdateInterval', -1)
+
+  try {
+    // act
+    await Command.execute('ProcessExplorer.handleClickAt', 1)
+
+    // assert
+    const focusedRow = Locator('.ProcessExplorerRowFocused[data-index="1"]')
+    await expect(focusedRow).toBeVisible()
+  } finally {
+    await Command.execute(
+      'ProcessExplorer.setUpdateInterval',
+      defaultUpdateInterval,
+    )
+  }
+}

--- a/packages/e2e/src/viewlet.process-explorer.focus-first.ts
+++ b/packages/e2e/src/viewlet.process-explorer.focus-first.ts
@@ -1,0 +1,26 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.focus-first'
+
+const defaultUpdateInterval = 1000
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+  await Command.execute('ProcessExplorer.setUpdateInterval', -1)
+
+  try {
+    // act
+    await Command.execute('ProcessExplorer.focusFirst')
+
+    // assert
+    const focusedRow = Locator('.ProcessExplorerRowFocused[data-index="0"]')
+    await expect(focusedRow).toBeVisible()
+    await expect(focusedRow).toHaveAttribute('tabindex', '0')
+  } finally {
+    await Command.execute(
+      'ProcessExplorer.setUpdateInterval',
+      defaultUpdateInterval,
+    )
+  }
+}

--- a/packages/e2e/src/viewlet.process-explorer.focus-last.ts
+++ b/packages/e2e/src/viewlet.process-explorer.focus-last.ts
@@ -1,0 +1,27 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.focus-last'
+
+const defaultUpdateInterval = 1000
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+  await Command.execute('ProcessExplorer.setUpdateInterval', -1)
+
+  try {
+    // act
+    await Command.execute('ProcessExplorer.focusLast')
+
+    // assert
+    const focusedRow = Locator(
+      '.ProcessExplorerTableBody > .ProcessExplorerRow:last-child.ProcessExplorerRowFocused',
+    )
+    await expect(focusedRow).toBeVisible()
+  } finally {
+    await Command.execute(
+      'ProcessExplorer.setUpdateInterval',
+      defaultUpdateInterval,
+    )
+  }
+}

--- a/packages/e2e/src/viewlet.process-explorer.focus-next-boundary.ts
+++ b/packages/e2e/src/viewlet.process-explorer.focus-next-boundary.ts
@@ -1,0 +1,29 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.focus-next-boundary'
+
+const defaultUpdateInterval = 1000
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+  await Command.execute('ProcessExplorer.setUpdateInterval', -1)
+
+  try {
+    await Command.execute('ProcessExplorer.focusLast')
+
+    // act
+    await Command.execute('ProcessExplorer.focusNext')
+
+    // assert
+    const focusedRow = Locator(
+      '.ProcessExplorerTableBody > .ProcessExplorerRow:last-child.ProcessExplorerRowFocused',
+    )
+    await expect(focusedRow).toBeVisible()
+  } finally {
+    await Command.execute(
+      'ProcessExplorer.setUpdateInterval',
+      defaultUpdateInterval,
+    )
+  }
+}

--- a/packages/e2e/src/viewlet.process-explorer.focus-next.ts
+++ b/packages/e2e/src/viewlet.process-explorer.focus-next.ts
@@ -1,0 +1,27 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.focus-next'
+
+const defaultUpdateInterval = 1000
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+  await Command.execute('ProcessExplorer.setUpdateInterval', -1)
+
+  try {
+    await Command.execute('ProcessExplorer.focusFirst')
+
+    // act
+    await Command.execute('ProcessExplorer.focusNext')
+
+    // assert
+    const focusedRow = Locator('.ProcessExplorerRowFocused[data-index="1"]')
+    await expect(focusedRow).toBeVisible()
+  } finally {
+    await Command.execute(
+      'ProcessExplorer.setUpdateInterval',
+      defaultUpdateInterval,
+    )
+  }
+}

--- a/packages/e2e/src/viewlet.process-explorer.focus-previous-boundary.ts
+++ b/packages/e2e/src/viewlet.process-explorer.focus-previous-boundary.ts
@@ -1,0 +1,27 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.focus-previous-boundary'
+
+const defaultUpdateInterval = 1000
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+  await Command.execute('ProcessExplorer.setUpdateInterval', -1)
+
+  try {
+    await Command.execute('ProcessExplorer.focusFirst')
+
+    // act
+    await Command.execute('ProcessExplorer.focusPrevious')
+
+    // assert
+    const focusedRow = Locator('.ProcessExplorerRowFocused[data-index="0"]')
+    await expect(focusedRow).toBeVisible()
+  } finally {
+    await Command.execute(
+      'ProcessExplorer.setUpdateInterval',
+      defaultUpdateInterval,
+    )
+  }
+}

--- a/packages/e2e/src/viewlet.process-explorer.focus-previous.ts
+++ b/packages/e2e/src/viewlet.process-explorer.focus-previous.ts
@@ -1,0 +1,28 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.focus-previous'
+
+const defaultUpdateInterval = 1000
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  // arrange
+  await Command.execute('Developer.openProcessExplorer')
+  await Command.execute('ProcessExplorer.setUpdateInterval', -1)
+
+  try {
+    await Command.execute('ProcessExplorer.focusFirst')
+    await Command.execute('ProcessExplorer.focusNext')
+
+    // act
+    await Command.execute('ProcessExplorer.focusPrevious')
+
+    // assert
+    const focusedRow = Locator('.ProcessExplorerRowFocused[data-index="0"]')
+    await expect(focusedRow).toBeVisible()
+  } finally {
+    await Command.execute(
+      'ProcessExplorer.setUpdateInterval',
+      defaultUpdateInterval,
+    )
+  }
+}


### PR DESCRIPTION
Adds 20 process explorer end-to-end tests covering accessibility semantics and focus navigation behavior across the supported browser matrix.