### PR TITLE
fix: split electron process explorer rpcs

### DIFF
--- a/packages/process-explorer-worker/src/parts/InitializeProcessExplorer/InitializeProcessExplorer.ts
+++ b/packages/process-explorer-worker/src/parts/InitializeProcessExplorer/InitializeProcessExplorer.ts
@@ -1,4 +1,5 @@
 import { PlatformType } from '@lvce-editor/constants'
+import { MainProcess } from '@lvce-editor/rpc-registry'
 import * as HandleProcessExplorerRpcClose from '../HandleProcessExplorerRpcClose/HandleProcessExplorerRpcClose.ts'
 import * as LaunchProcessExplorerElectron from '../LaunchProcessExplorerElectron/LaunchProcessExplorerElectron.ts'
 import * as LaunchProcessExplorerNode from '../LaunchProcessExplorerNode/LaunchProcessExplorerNode.ts'
@@ -25,9 +26,10 @@ export const initializeProcessExplorer = async (
     return
   }
   if (platform === PlatformType.Electron) {
-    const rpc =
+    const { mainProcessRpc, processExplorerRpc } =
       await LaunchProcessExplorerElectron.launchProcessExplorerElectron()
-    ProcessExplorerModule.set(rpc)
+    MainProcess.set(mainProcessRpc)
+    ProcessExplorerModule.set(processExplorerRpc)
     state.initializedPlatform = platform
     return
   }
@@ -47,6 +49,11 @@ export const clear = (): void => {
 }
 
 export const dispose = async (): Promise<void> => {
+  const { initializedPlatform } = state
   state.initializedPlatform = 0
+  if (initializedPlatform === PlatformType.Electron) {
+    await Promise.all([MainProcess.dispose(), ProcessExplorerModule.dispose()])
+    return
+  }
   await ProcessExplorerModule.dispose()
 }

--- a/packages/process-explorer-worker/src/parts/LaunchProcessExplorerElectron/LaunchProcessExplorerElectron.ts
+++ b/packages/process-explorer-worker/src/parts/LaunchProcessExplorerElectron/LaunchProcessExplorerElectron.ts
@@ -2,15 +2,38 @@ import type { Rpc } from '@lvce-editor/rpc'
 import { LazyTransferMessagePortRpcParent } from '@lvce-editor/rpc'
 import { VError } from '@lvce-editor/verror'
 import * as SendMessagePortToMainProcess from '../SendMessagePortToMainProcess/SendMessagePortToMainProcess.ts'
+import * as SendMessagePortToProcessExplorer from '../SendMessagePortToProcessExplorer/SendMessagePortToProcessExplorer.ts'
 
-export const launchProcessExplorerElectron = async (): Promise<Rpc> => {
-  try {
-    const rpc = await LazyTransferMessagePortRpcParent.create({
-      commandMap: {},
-      send: SendMessagePortToMainProcess.sendMessagePortToMainProcess,
-    })
-    return rpc
-  } catch (error) {
-    throw new VError(error, 'Failed to create process explorer electron rpc')
-  }
+export interface ProcessExplorerElectronRpcs {
+  readonly mainProcessRpc: Rpc
+  readonly processExplorerRpc: Rpc
 }
+
+const createRpc = async (
+  send: (port: MessagePort) => Promise<void>,
+): Promise<Rpc> => {
+  return LazyTransferMessagePortRpcParent.create({
+    commandMap: {},
+    send,
+  })
+}
+
+export const launchProcessExplorerElectron =
+  async (): Promise<ProcessExplorerElectronRpcs> => {
+    let processExplorerRpc: Rpc | undefined
+    try {
+      processExplorerRpc = await createRpc(
+        SendMessagePortToProcessExplorer.sendMessagePortToProcessExplorer,
+      )
+      const mainProcessRpc = await createRpc(
+        SendMessagePortToMainProcess.sendMessagePortToMainProcess,
+      )
+      return {
+        mainProcessRpc,
+        processExplorerRpc,
+      }
+    } catch (error) {
+      await processExplorerRpc?.dispose()
+      throw new VError(error, 'Failed to create process explorer electron rpcs')
+    }
+  }

--- a/packages/process-explorer-worker/src/parts/Refresh/Refresh.ts
+++ b/packages/process-explorer-worker/src/parts/Refresh/Refresh.ts
@@ -1,4 +1,5 @@
 import { PlatformType } from '@lvce-editor/constants'
+import { MainProcess } from '@lvce-editor/rpc-registry'
 import type { ProcessExplorerState } from '../ProcessExplorerState/ProcessExplorerState.ts'
 import type { ProcessInfo } from '../ProcessInfo/ProcessInfo.ts'
 import * as GetFrontendMemoryUsage from '../GetFrontendMemoryUsage/GetFrontendMemoryUsage.ts'
@@ -20,6 +21,26 @@ const getFocusedIndex = (
   return Math.min(oldFocusedIndex, visibleProcesses.length - 1)
 }
 
+const listProcesses = async (
+  rootPid: number,
+  platform: number,
+): Promise<readonly ProcessInfo[]> => {
+  if (platform === PlatformType.Electron) {
+    const pidMap = await MainProcess.invoke('CreatePidMap.createPidMap')
+    return ProcessExplorerModule.invoke(
+      'ListProcessesWithMemoryUsage.listProcessesWithMemoryUsage',
+      rootPid,
+      false,
+      pidMap,
+    )
+  }
+  return ProcessExplorerModule.invoke(
+    'ListProcessesWithMemoryUsage.listProcessesWithMemoryUsage',
+    rootPid,
+    false,
+  )
+}
+
 export const refresh = async (
   state: ProcessExplorerState,
 ): Promise<ProcessExplorerState> => {
@@ -32,12 +53,7 @@ export const refresh = async (
             includeElectronData,
           })
         : state.rootPid
-    const processes: readonly ProcessInfo[] =
-      await ProcessExplorerModule.invoke(
-        'ListProcessesWithMemoryUsage.listProcessesWithMemoryUsage',
-        rootPid,
-        includeElectronData,
-      )
+    const processes = await listProcesses(rootPid, state.platform)
     const frontendMemoryProcesses = state.includeFrontendMemoryUsage
       ? await GetFrontendMemoryUsage.getFrontendMemoryUsage(rootPid)
       : []

--- a/packages/process-explorer-worker/src/parts/SendMessagePortToProcessExplorer/SendMessagePortToProcessExplorer.ts
+++ b/packages/process-explorer-worker/src/parts/SendMessagePortToProcessExplorer/SendMessagePortToProcessExplorer.ts
@@ -1,0 +1,7 @@
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+
+export const sendMessagePortToProcessExplorer = async (
+  port: MessagePort,
+): Promise<void> => {
+  await RendererWorker.sendMessagePortToProcessExplorer(port)
+}

--- a/packages/process-explorer-worker/test/InitializeProcessExplorer.test.ts
+++ b/packages/process-explorer-worker/test/InitializeProcessExplorer.test.ts
@@ -1,19 +1,35 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import { PlatformType } from '@lvce-editor/constants'
 
-const electronRpc = {
+const mainProcessRpc = {
+  invoke: jest.fn(),
+}
+const processExplorerRpc = {
   invoke: jest.fn(),
 }
 const nodeRpc = {
   invoke: jest.fn(),
 }
-const launchProcessExplorerElectron = jest.fn(async () => electronRpc)
+const launchProcessExplorerElectron = jest.fn(async () => ({
+  mainProcessRpc,
+  processExplorerRpc,
+}))
 const launchProcessExplorerNode = jest.fn(
   async (_onClose: () => void) => nodeRpc,
 )
 const handleProcessExplorerRpcClose = jest.fn(async () => {})
+const disposeMainProcess = jest.fn(async () => {})
+const disposeProcessExplorer = jest.fn(async () => {})
+const setMainProcess = jest.fn()
 const clear = jest.fn()
-const set = jest.fn()
+const setProcessExplorer = jest.fn()
+
+jest.unstable_mockModule('@lvce-editor/rpc-registry', () => ({
+  MainProcess: {
+    dispose: disposeMainProcess,
+    set: setMainProcess,
+  },
+}))
 
 jest.unstable_mockModule(
   '../src/parts/HandleProcessExplorerRpcClose/HandleProcessExplorerRpcClose.ts',
@@ -40,7 +56,8 @@ jest.unstable_mockModule(
   '../src/parts/ProcessExplorer/ProcessExplorer.ts',
   () => ({
     clear,
-    set,
+    dispose: disposeProcessExplorer,
+    set: setProcessExplorer,
   }),
 )
 
@@ -59,7 +76,8 @@ test('initializeProcessExplorer - electron', async () => {
 
   expect(launchProcessExplorerElectron).toHaveBeenCalledTimes(1)
   expect(launchProcessExplorerNode).not.toHaveBeenCalled()
-  expect(set).toHaveBeenCalledWith(electronRpc)
+  expect(setMainProcess).toHaveBeenCalledWith(mainProcessRpc)
+  expect(setProcessExplorer).toHaveBeenCalledWith(processExplorerRpc)
 })
 
 test('initializeProcessExplorer - already initialized', async () => {
@@ -72,7 +90,8 @@ test('initializeProcessExplorer - already initialized', async () => {
 
   expect(launchProcessExplorerElectron).toHaveBeenCalledTimes(1)
   expect(launchProcessExplorerNode).not.toHaveBeenCalled()
-  expect(set).toHaveBeenCalledTimes(1)
+  expect(setMainProcess).toHaveBeenCalledTimes(1)
+  expect(setProcessExplorer).toHaveBeenCalledTimes(1)
 })
 
 test('initializeProcessExplorer - remote', async () => {
@@ -81,7 +100,8 @@ test('initializeProcessExplorer - remote', async () => {
   expect(launchProcessExplorerNode).toHaveBeenCalledTimes(1)
   expect(launchProcessExplorerNode).toHaveBeenCalledWith(expect.any(Function))
   expect(launchProcessExplorerElectron).not.toHaveBeenCalled()
-  expect(set).toHaveBeenCalledWith(nodeRpc)
+  expect(setMainProcess).not.toHaveBeenCalled()
+  expect(setProcessExplorer).toHaveBeenCalledWith(nodeRpc)
 })
 
 test('initializeProcessExplorer - remote connection closes', async () => {
@@ -102,5 +122,26 @@ test('initializeProcessExplorer - other platform', async () => {
 
   expect(launchProcessExplorerElectron).not.toHaveBeenCalled()
   expect(launchProcessExplorerNode).not.toHaveBeenCalled()
-  expect(set).not.toHaveBeenCalled()
+  expect(setMainProcess).not.toHaveBeenCalled()
+  expect(setProcessExplorer).not.toHaveBeenCalled()
+})
+
+test('dispose - electron rpcs', async () => {
+  await InitializeProcessExplorer.initializeProcessExplorer(
+    PlatformType.Electron,
+  )
+
+  await InitializeProcessExplorer.dispose()
+
+  expect(disposeMainProcess).toHaveBeenCalledTimes(1)
+  expect(disposeProcessExplorer).toHaveBeenCalledTimes(1)
+})
+
+test('dispose - remote rpc', async () => {
+  await InitializeProcessExplorer.initializeProcessExplorer(PlatformType.Remote)
+
+  await InitializeProcessExplorer.dispose()
+
+  expect(disposeMainProcess).not.toHaveBeenCalled()
+  expect(disposeProcessExplorer).toHaveBeenCalledTimes(1)
 })

--- a/packages/process-explorer-worker/test/LaunchProcessExplorerElectron.test.ts
+++ b/packages/process-explorer-worker/test/LaunchProcessExplorerElectron.test.ts
@@ -1,11 +1,20 @@
-import { expect, jest, test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const invokeAndTransfer = jest.fn(
   async (..._args: readonly unknown[]) => undefined,
 )
-const mockRpc = {
+const sendMessagePortToProcessExplorer = jest.fn(
+  async (_port: MessagePort) => undefined,
+)
+const processExplorerRpc = {
+  dispose: jest.fn(async () => {}),
   invoke: jest.fn(),
 }
+const mainProcessRpc = {
+  dispose: jest.fn(async () => {}),
+  invoke: jest.fn(),
+}
+const rpcs = [processExplorerRpc, mainProcessRpc]
 const create = jest.fn(
   async ({
     send,
@@ -14,7 +23,7 @@ const create = jest.fn(
     readonly send: (port: MessagePort) => Promise<void>
   }) => {
     await send({} as MessagePort)
-    return mockRpc
+    return rpcs[create.mock.calls.length - 1]
   },
 )
 
@@ -27,25 +36,50 @@ jest.unstable_mockModule('@lvce-editor/rpc', () => ({
 jest.unstable_mockModule('@lvce-editor/rpc-registry', () => ({
   RendererWorker: {
     invokeAndTransfer,
+    sendMessagePortToProcessExplorer,
   },
 }))
 
 const LaunchProcessExplorerElectron =
   await import('../src/parts/LaunchProcessExplorerElectron/LaunchProcessExplorerElectron.ts')
 
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
 test('launchProcessExplorerElectron - creates rpc and sends message port', async () => {
-  const rpc =
+  const rpcs =
     await LaunchProcessExplorerElectron.launchProcessExplorerElectron()
 
-  expect(rpc).toBe(mockRpc)
-  expect(create).toHaveBeenCalledWith({
-    commandMap: {},
-    send: expect.any(Function),
+  expect(rpcs).toEqual({
+    mainProcessRpc,
+    processExplorerRpc,
   })
+  expect(create).toHaveBeenCalledTimes(2)
+  expect(sendMessagePortToProcessExplorer).toHaveBeenCalledWith(
+    expect.anything(),
+  )
   expect(invokeAndTransfer).toHaveBeenCalledWith(
     'SendMessagePortToMainProcess.sendMessagePortToMainProcess',
     expect.anything(),
     'HandleElectronMessagePort.handleElectronMessagePort',
     33,
   )
+})
+
+test('launchProcessExplorerElectron - disposes process explorer rpc when main process rpc creation fails', async () => {
+  create
+    .mockImplementationOnce(async ({ send }) => {
+      await send({} as MessagePort)
+      return processExplorerRpc
+    })
+    .mockRejectedValueOnce(new Error('Failed to connect to main process'))
+
+  await expect(
+    LaunchProcessExplorerElectron.launchProcessExplorerElectron(),
+  ).rejects.toThrow(
+    'Failed to create process explorer electron rpcs: Failed to connect to main process',
+  )
+
+  expect(processExplorerRpc.dispose).toHaveBeenCalledTimes(1)
 })

--- a/packages/process-explorer-worker/test/Refresh.test.ts
+++ b/packages/process-explorer-worker/test/Refresh.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
 import { PlatformType } from '@lvce-editor/constants'
 import { createMockRpc } from '@lvce-editor/rpc'
-import { ErrorWorker } from '@lvce-editor/rpc-registry'
+import { ErrorWorker, MainProcess } from '@lvce-editor/rpc-registry'
 
 const initializeProcessExplorer = jest.fn(
   async (..._args: readonly unknown[]) => {},
@@ -52,6 +52,17 @@ const registerProcessExplorerMock = (
   return {
     [Symbol.dispose](): void {
       ProcessExplorerModule.clear()
+    },
+  }
+}
+
+const registerMainProcessMock = (
+  commandMap: Record<string, unknown>,
+): DisposableMockRpc => {
+  MainProcess.set(createMockRpc({ commandMap }))
+  return {
+    [Symbol.dispose](): void {
+      MainProcess.set(createMockRpc({ commandMap: {} }))
     },
   }
 }
@@ -126,6 +137,10 @@ test('refresh - success - remote', async () => {
 })
 
 test('refresh - success - electron', async () => {
+  const pidMap = {
+    2: 'shared-process',
+  }
+  const createPidMap = jest.fn(() => pidMap)
   const listProcessesWithMemoryUsage = jest.fn(
     (..._args: readonly unknown[]) => processes,
   )
@@ -135,6 +150,9 @@ test('refresh - success - electron', async () => {
       listProcessesWithMemoryUsage,
     'ProcessId.getMainProcessId': getMainProcessId,
   })
+  using _mockMainProcessRpc = registerMainProcessMock({
+    'CreatePidMap.createPidMap': createPidMap,
+  })
   const result = await Refresh.refresh({
     ...createDefaultState(),
     platform: PlatformType.Electron,
@@ -143,7 +161,8 @@ test('refresh - success - electron', async () => {
   expect(result.rootPid).toBe(1)
   expect(initializeProcessExplorer).toHaveBeenCalledWith(PlatformType.Electron)
   expect(getMainProcessId).toHaveBeenCalledWith({ includeElectronData: true })
-  expect(listProcessesWithMemoryUsage).toHaveBeenCalledWith(1, true)
+  expect(createPidMap).toHaveBeenCalledTimes(1)
+  expect(listProcessesWithMemoryUsage).toHaveBeenCalledWith(1, false, pidMap)
 })
 
 test('refresh - uses existing root pid', async () => {

--- a/packages/process-explorer/src/parts/GetListProcessesWithMemoryUsageModule/GetListProcessesWithMemoryUsageModule.ts
+++ b/packages/process-explorer/src/parts/GetListProcessesWithMemoryUsageModule/GetListProcessesWithMemoryUsageModule.ts
@@ -1,3 +1,4 @@
+import type { PidMap } from '../PidMap/PidMap.ts'
 import type {
   ProcessItem,
   ProcessItemWithDepth,
@@ -8,6 +9,7 @@ export interface ListProcessesWithMemoryUsageModule {
   readonly listProcessesWithMemoryUsage: (
     rootPid: number,
     includeElectronData?: boolean,
+    pidMap?: PidMap,
   ) => Promise<readonly ProcessItem[] | readonly ProcessItemWithDepth[]>
 }
 

--- a/packages/process-explorer/src/parts/ListProcessesWithMemoryUsage/ListProcessesWithMemoryUsage.ts
+++ b/packages/process-explorer/src/parts/ListProcessesWithMemoryUsage/ListProcessesWithMemoryUsage.ts
@@ -1,3 +1,4 @@
+import type { PidMap } from '../PidMap/PidMap.ts'
 import type {
   ProcessItem,
   ProcessItemWithDepth,
@@ -7,7 +8,12 @@ import * as GetListProcessesWithMemoryUsageModule from '../GetListProcessesWithM
 export const listProcessesWithMemoryUsage = async (
   rootPid: number,
   includeElectronData = true,
+  pidMap?: PidMap,
 ): Promise<readonly ProcessItem[] | readonly ProcessItemWithDepth[]> => {
   const module = await GetListProcessesWithMemoryUsageModule.getModule()
-  return module.listProcessesWithMemoryUsage(rootPid, includeElectronData)
+  return module.listProcessesWithMemoryUsage(
+    rootPid,
+    includeElectronData,
+    pidMap,
+  )
 }

--- a/packages/process-explorer/src/parts/ListProcessesWithMemoryUsageUnix/ListProcessesWithMemoryUsageUnix.ts
+++ b/packages/process-explorer/src/parts/ListProcessesWithMemoryUsageUnix/ListProcessesWithMemoryUsageUnix.ts
@@ -1,3 +1,4 @@
+import type { PidMap } from '../PidMap/PidMap.ts'
 import type { ProcessItemWithDepth } from '../ProcessItem/ProcessItem.ts'
 import * as AddAccurateMemoryUsage from '../AddAccurateMemoryUsage/AddAccurateMemoryUsage.ts'
 import * as CreatePidMap from '../CreatePidMap/CreatePidMap.ts'
@@ -8,10 +9,13 @@ import * as ParsePsOutput from '../ParsePsOutput/ParsePsOutput.ts'
 export const listProcessesWithMemoryUsage = async (
   rootPid: number,
   includeElectronData = true,
+  electronPidMap?: PidMap,
 ): Promise<readonly ProcessItemWithDepth[]> => {
   // console.time('getPsOutput')
   const stdout = await GetPsOutput.getPsOutput()
-  const pidMap = includeElectronData ? await CreatePidMap.createPidMap() : {}
+  const pidMap =
+    electronPidMap ??
+    (includeElectronData ? await CreatePidMap.createPidMap() : {})
   // console.log({ stdout })
   // console.timeEnd('getPsOutput')
   // console.time('parsePsOutput')

--- a/packages/process-explorer/src/parts/ListProcessesWithMemoryUsageWindows/ListProcessesWithMemoryUsageWindows.ts
+++ b/packages/process-explorer/src/parts/ListProcessesWithMemoryUsageWindows/ListProcessesWithMemoryUsageWindows.ts
@@ -1,6 +1,7 @@
 // listProcesses windows implementation based on https://github.com/microsoft/vscode/blob/c0769274fa136b45799edeccc0d0a2f645b75caf/src/vs/base/node/ps.ts (License MIT)
 
 import type { CompleteProcessInfo } from '../CompleteProcessInfo/CompleteProcessInfo.ts'
+import type { PidMap } from '../PidMap/PidMap.ts'
 import type { ProcessItem } from '../ProcessItem/ProcessItem.ts'
 import * as AddWindowsProcessCpuUsage from '../AddWindowsProcessCpuUsage/AddWindowsProcessCpuUsage.ts'
 import * as CreatePidMap from '../CreatePidMap/CreatePidMap.ts'
@@ -12,6 +13,7 @@ import * as WindowsProcessTreeDataFlag from '../WindowsProcessTreeDataFlag/Windo
 export const listProcessesWithMemoryUsage = async (
   rootPid: number,
   includeElectronData = true,
+  electronPidMap?: PidMap,
 ): Promise<readonly ProcessItem[]> => {
   try {
     const processList = await GetWindowsProcessList.getProcessList(
@@ -22,7 +24,9 @@ export const listProcessesWithMemoryUsage = async (
     if (!processList) {
       throw new VError(`Root process ${rootPid} not found`)
     }
-    const pidMap = includeElectronData ? await CreatePidMap.createPidMap() : {}
+    const pidMap =
+      electronPidMap ??
+      (includeElectronData ? await CreatePidMap.createPidMap() : {})
     const completeProcessList =
       await AddWindowsProcessCpuUsage.addCpuUsage(processList)
     const result = ToResult.toResult(

--- a/packages/process-explorer/src/parts/PidMap/PidMap.ts
+++ b/packages/process-explorer/src/parts/PidMap/PidMap.ts
@@ -1,0 +1,1 @@
+export type PidMap = Readonly<Record<number, string>>

--- a/packages/process-explorer/test/ListProcessesWithMemoryUsageUnix.test.ts
+++ b/packages/process-explorer/test/ListProcessesWithMemoryUsageUnix.test.ts
@@ -156,6 +156,43 @@ test('listProcessesWithMemoryUsage - without electron data', async () => {
   expect(createPidMap).not.toHaveBeenCalled()
 })
 
+test('listProcessesWithMemoryUsage - with provided electron pid map', async () => {
+  // @ts-ignore
+  childProcess.execFile.mockImplementation((command, args, callback) => {
+    callback(null, {
+      stdout: `1442       1  0.0  0.2 electron
+2127    1442  0.0  0.2 electron --type=utility
+`,
+    })
+  })
+  // @ts-ignore
+  fsPromises.readFile.mockImplementation(() => '41700 2023 1199 224 0 5027 0')
+
+  await expect(
+    ListProcessesWithMemoryUsage.listProcessesWithMemoryUsage(1442, false, {
+      2127: 'shared-process',
+    }),
+  ).resolves.toEqual([
+    {
+      cmd: 'electron',
+      depth: 1,
+      memory: 8_286_208,
+      name: 'main',
+      pid: 1442,
+      ppid: 1,
+    },
+    {
+      cmd: 'electron --type=utility',
+      depth: 2,
+      memory: 8_286_208,
+      name: 'shared-process',
+      pid: 2127,
+      ppid: 1442,
+    },
+  ])
+  expect(createPidMap).not.toHaveBeenCalled()
+})
+
 test('listProcessesWithMemoryUsage - bug with parsing this specific line', async () => {
   // @ts-ignore
   childProcess.execFile.mockImplementation((command, args, callback) => {

--- a/packages/process-explorer/test/ListProcessesWithMemoryUsageWindows.test.ts
+++ b/packages/process-explorer/test/ListProcessesWithMemoryUsageWindows.test.ts
@@ -231,6 +231,42 @@ test('listProcessesWithMemoryUsage - without electron data', async () => {
   expect(createPidMap).not.toHaveBeenCalled()
 })
 
+test('listProcessesWithMemoryUsage - with provided electron pid map', async () => {
+  const processList = [
+    {
+      commandLine: 'electron --type=utility',
+      cpu: 0,
+      memory: 1,
+      name: 'electron.exe',
+      pid: 7004,
+      ppid: 9176,
+    },
+  ]
+  // @ts-ignore
+  WindowsProcessTree.getProcessList.mockImplementation((rootPid, callback) => {
+    callback(processList)
+  })
+  // @ts-ignore
+  WindowsProcessTree.getProcessCpuUsage.mockImplementation((list, callback) => {
+    callback(list)
+  })
+
+  await expect(
+    ListProcessesWithMemoryUsage.listProcessesWithMemoryUsage(25_666, false, {
+      7004: 'shared-process',
+    }),
+  ).resolves.toEqual([
+    {
+      cmd: 'electron --type=utility',
+      memory: 1,
+      name: 'shared-process',
+      pid: 7004,
+      ppid: 9176,
+    },
+  ])
+  expect(createPidMap).not.toHaveBeenCalled()
+})
+
 test('listProcessesWithMemoryUsage - error - rootPid not found', async () => {
   // @ts-ignore
   WindowsProcessTree.getProcessList.mockImplementation((rootPid, callback) => {


### PR DESCRIPTION
Routes Electron process enumeration through the process-explorer service while using a separate main-process RPC for PID display names. This fixes the command-not-found error and preserves pretty utility-process names.