### PR TITLE
Request WebSocket capabilities for process explorer RPC

### DIFF
--- a/packages/process-explorer-worker/src/parts/LaunchProcessExplorerNode/LaunchProcessExplorerNode.ts
+++ b/packages/process-explorer-worker/src/parts/LaunchProcessExplorerNode/LaunchProcessExplorerNode.ts
@@ -1,11 +1,38 @@
 import type { Rpc } from '@lvce-editor/rpc'
-import { LazyWebSocketRpcParent2 } from '@lvce-editor/rpc'
+import { LazyWebSocketRpcParent2, WebSocketRpcParent } from '@lvce-editor/rpc'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import { VError } from '@lvce-editor/verror'
+
+const commandNotFoundRegex = /command not found|not found/i
 
 export const launchProcessExplorerNode = async (
   onClose: () => void,
 ): Promise<Rpc> => {
   try {
+    try {
+      const { protocols, url } = (await RendererWorker.invoke(
+        'WebSocketCapability.create',
+        'process-explorer',
+      )) as {
+        readonly protocols: string[]
+        readonly url: string
+      }
+      const webSocket = new WebSocket(url, protocols)
+      webSocket.addEventListener('close', onClose)
+      return await WebSocketRpcParent.create({
+        commandMap: {},
+        webSocket,
+      })
+    } catch (error) {
+      if (!(
+        error instanceof Error &&
+        (error.message.includes('WebSocketCapability.create') ||
+          error.message.includes('module WebSocketCapability not found')) &&
+        commandNotFoundRegex.test(error.message)
+      )) {
+        throw error
+      }
+    }
     const rpc = await LazyWebSocketRpcParent2.create({
       commandMap: {},
       onClose,

--- a/packages/process-explorer-worker/test/LaunchProcessExplorerNode.test.ts
+++ b/packages/process-explorer-worker/test/LaunchProcessExplorerNode.test.ts
@@ -3,31 +3,74 @@ import { expect, jest, test } from '@jest/globals'
 const mockRpc = {
   invoke: jest.fn(),
 }
-const create = jest.fn(
-  async (_options: {
-    readonly commandMap: Readonly<Record<string, any>>
-    readonly onClose?: () => void
-    readonly type: string
-  }) => mockRpc,
-)
+const create = jest.fn(async (_options: unknown) => mockRpc)
+const createLazy = jest.fn(async (_options: unknown) => mockRpc)
+const invoke = jest.fn(async (_method: string, _type: string) => ({
+  protocols: ['lvce-rpc', 'lvce-capability.token'],
+  url: 'ws://localhost/websocket/capability',
+}))
 
 jest.unstable_mockModule('@lvce-editor/rpc', () => ({
   LazyWebSocketRpcParent2: {
+    create: createLazy,
+  },
+  WebSocketRpcParent: {
     create,
+  },
+}))
+
+jest.unstable_mockModule('@lvce-editor/rpc-registry', () => ({
+  RendererWorker: {
+    invoke,
   },
 }))
 
 const LaunchProcessExplorerNode =
   await import('../src/parts/LaunchProcessExplorerNode/LaunchProcessExplorerNode.ts')
 
-test('launchProcessExplorerNode - creates websocket rpc', async () => {
+test('launchProcessExplorerNode - creates a capability websocket rpc', async () => {
   const onClose = jest.fn()
+  const addEventListener = jest.fn()
+  const webSocket = { addEventListener }
+  const MockWebSocket = jest.fn(
+    (_url: string, _protocols: readonly string[]) => webSocket,
+  )
+  Object.defineProperty(globalThis, 'WebSocket', {
+    configurable: true,
+    value: MockWebSocket,
+  })
+
   const rpc = await LaunchProcessExplorerNode.launchProcessExplorerNode(onClose)
 
   expect(rpc).toBe(mockRpc)
+  expect(invoke).toHaveBeenCalledWith(
+    'WebSocketCapability.create',
+    'process-explorer',
+  )
+  expect(MockWebSocket).toHaveBeenCalledWith(
+    'ws://localhost/websocket/capability',
+    ['lvce-rpc', 'lvce-capability.token'],
+  )
+  expect(addEventListener).toHaveBeenCalledWith('close', onClose)
   expect(create).toHaveBeenCalledWith({
     commandMap: {},
-    onClose,
+    webSocket,
+  })
+})
+
+test('launchProcessExplorerNode - falls back when an older renderer has no capability module', async () => {
+  invoke.mockRejectedValueOnce(
+    new Error('module WebSocketCapability not found'),
+  )
+
+  const rpc = await LaunchProcessExplorerNode.launchProcessExplorerNode(
+    jest.fn(),
+  )
+
+  expect(rpc).toBe(mockRpc)
+  expect(createLazy).toHaveBeenCalledWith({
+    commandMap: {},
+    onClose: expect.any(Function),
     type: 'process-explorer',
   })
 })


### PR DESCRIPTION
Requests a renderer-issued one-use capability before connecting to process explorer, with a command-missing fallback for older editors.