### PR TITLE
feature: show friendly Zig language server name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Lvce Editor Process Explorer
 
 Process Explorer.
+
+Friendly names for executable paths can be added to
+`packages/process-explorer/src/parts/ConfiguredProcessNames/configuredProcessNames.json`.
+Each entry contains a `pathRegex` matched against the full process command and the
+`displayName` shown in Process Explorer.

--- a/packages/build/src/build.ts
+++ b/packages/build/src/build.ts
@@ -93,6 +93,18 @@ await bundleJs({
 await cp(join(root, 'packages', 'process-explorer', 'bin'), join(dist, 'bin'), {
   recursive: true,
 })
+await cp(
+  join(
+    root,
+    'packages',
+    'process-explorer',
+    'src',
+    'parts',
+    'ConfiguredProcessNames',
+    'configuredProcessNames.json',
+  ),
+  join(dist, 'dist', 'configuredProcessNames.json'),
+)
 
 await replace({
   path: join(dist, 'bin', 'processExplorer.js'),

--- a/packages/process-explorer/src/parts/ConfiguredProcessNames/ConfiguredProcessNames.ts
+++ b/packages/process-explorer/src/parts/ConfiguredProcessNames/ConfiguredProcessNames.ts
@@ -11,7 +11,7 @@ interface CompiledProcessName {
 }
 
 const configuredProcessNames = JSON.parse(
-  readFileSync(new URL('./configuredProcessNames.json', import.meta.url), 'utf8'),
+  readFileSync(new URL('configuredProcessNames.json', import.meta.url), 'utf8'),
 ) as readonly ConfiguredProcessName[]
 
 const compiledProcessNames: readonly CompiledProcessName[] =

--- a/packages/process-explorer/src/parts/ConfiguredProcessNames/ConfiguredProcessNames.ts
+++ b/packages/process-explorer/src/parts/ConfiguredProcessNames/ConfiguredProcessNames.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs'
+
+interface ConfiguredProcessName {
+  readonly displayName: string
+  readonly pathRegex: string
+}
+
+interface CompiledProcessName {
+  readonly displayName: string
+  readonly pathRegex: RegExp
+}
+
+const configuredProcessNames = JSON.parse(
+  readFileSync(new URL('./configuredProcessNames.json', import.meta.url), 'utf8'),
+) as readonly ConfiguredProcessName[]
+
+const compiledProcessNames: readonly CompiledProcessName[] =
+  configuredProcessNames.map(({ displayName, pathRegex }) => ({
+    displayName,
+    pathRegex: new RegExp(pathRegex),
+  }))
+
+export const getConfiguredProcessName = (cmd: string): string => {
+  return (
+    compiledProcessNames.find(({ pathRegex }) => pathRegex.test(cmd))
+      ?.displayName || ''
+  )
+}

--- a/packages/process-explorer/src/parts/ConfiguredProcessNames/configuredProcessNames.json
+++ b/packages/process-explorer/src/parts/ConfiguredProcessNames/configuredProcessNames.json
@@ -1,0 +1,6 @@
+[
+  {
+    "pathRegex": "[/\\\\]language-server[/\\\\]zls(?:\\.exe)?(?:[\\s\\\"']|$)",
+    "displayName": "Zig Language Server"
+  }
+]

--- a/packages/process-explorer/src/parts/ListProcessGetName/ListProcessGetName.ts
+++ b/packages/process-explorer/src/parts/ListProcessGetName/ListProcessGetName.ts
@@ -1,4 +1,5 @@
 import * as Assert from '../Assert/Assert.ts'
+import * as ConfiguredProcessNames from '../ConfiguredProcessNames/ConfiguredProcessNames.ts'
 import * as GetFallbackPatternName from '../GetFallbackPatternName/GetFallbackPatternName.ts'
 import * as GetPatternName from '../GetPatternName/GetPatternName.ts'
 
@@ -18,6 +19,11 @@ export const getName = (
   const patternName = GetPatternName.getPatternName(cmd)
   if (patternName) {
     return patternName
+  }
+  const configuredProcessName =
+    ConfiguredProcessNames.getConfiguredProcessName(cmd)
+  if (configuredProcessName) {
+    return configuredProcessName
   }
   if (pid in pidMap) {
     return pidMap[pid] || '<unknown>'

--- a/packages/process-explorer/test/ListProcessGetName.test.ts
+++ b/packages/process-explorer/test/ListProcessGetName.test.ts
@@ -52,6 +52,30 @@ test('getName - detect extension host helper process', () => {
   )
 })
 
+test('getName - detect Zig language server', () => {
+  const pid = 123
+  const rootPid = 1
+  const pidMap = {
+    123: 'utility',
+  }
+  expect(
+    ListProcessGetName.getName(
+      pid,
+      '/home/simon/.local/share/lvce/extensions/language-features-zig/dist/language-server/zls',
+      rootPid,
+      pidMap,
+    ),
+  ).toBe('Zig Language Server')
+  expect(
+    ListProcessGetName.getName(
+      pid,
+      'C:\\Users\\simon\\extensions\\language-features-zig\\dist\\language-server\\zls.exe --enable-debug-log',
+      rootPid,
+      pidMap,
+    ),
+  ).toBe('Zig Language Server')
+})
+
 test('getName - detect sublime', () => {
   const pid = 123
   const cmd = '/opt/sublime_text/sublime_text --fwdargv0 /usr/bin/subl'


### PR DESCRIPTION
Adds a JSON-backed process path mapping so ZLS processes are displayed as Zig Language Server. The mapping supports Unix and Windows executable paths and can be extended with more regex/display-name entries.