### PR TITLE
Render directly in renderer process

### DIFF
--- a/packages/process-explorer-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/process-explorer-worker/src/parts/CommandMap/CommandMap.ts
@@ -20,6 +20,7 @@ import * as HandleClickAt from '../HandleClickAt/HandleClickAt.ts'
 import * as HandleContextMenu from '../HandleContextMenu/HandleContextMenu.ts'
 import * as HandleDoubleClick from '../HandleDoubleClick/HandleDoubleClick.ts'
 import * as HandleFocus from '../HandleFocus/HandleFocus.ts'
+import { handleMessagePort } from '../HandleMessagePort/HandleMessagePort.ts'
 import * as KillProcess from '../KillProcess/KillProcess.ts'
 import * as LoadContent from '../LoadContent/LoadContent.ts'
 import * as ProcessExplorerStates from '../ProcessExplorerStates/ProcessExplorerStates.ts'
@@ -88,6 +89,7 @@ export const commandMap = {
   'ProcessExplorer.handleFocus': ProcessExplorerStates.wrapCommand(
     HandleFocus.handleFocus,
   ),
+  'ProcessExplorer.handleMessagePort': handleMessagePort,
   'ProcessExplorer.killProcess': ProcessExplorerStates.wrapCommand(
     KillProcess.killProcess,
   ),

--- a/packages/process-explorer-worker/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/process-explorer-worker/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -1,0 +1,7 @@
+import { PlainMessagePortRpc } from '@lvce-editor/rpc'
+import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
+
+export const handleMessagePort = async (port: MessagePort): Promise<void> => {
+  const rpc = await PlainMessagePortRpc.create({ commandMap: {}, messagePort: port })
+  RendererProcess.set(rpc)
+}

--- a/packages/process-explorer-worker/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/process-explorer-worker/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -2,6 +2,9 @@ import { PlainMessagePortRpc } from '@lvce-editor/rpc'
 import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 
 export const handleMessagePort = async (port: MessagePort): Promise<void> => {
-  const rpc = await PlainMessagePortRpc.create({ commandMap: {}, messagePort: port })
+  const rpc = await PlainMessagePortRpc.create({
+    commandMap: {},
+    messagePort: port,
+  })
   RendererProcess.set(rpc)
 }

--- a/packages/process-explorer-worker/src/parts/Render2/Render2.ts
+++ b/packages/process-explorer-worker/src/parts/Render2/Render2.ts
@@ -1,11 +1,21 @@
 import * as ApplyRender from '../ApplyRender/ApplyRender.ts'
 import * as ProcessExplorerStates from '../ProcessExplorerStates/ProcessExplorerStates.ts'
+import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 
 export const render2 = (
   uid: number,
   diffResult: readonly number[],
-): readonly any[] => {
+): readonly any[] | Promise<readonly any[]> => {
   const { oldState, scheduledState } = ProcessExplorerStates.get(uid)
   ProcessExplorerStates.set(uid, scheduledState, scheduledState)
-  return ApplyRender.applyRender(oldState, scheduledState, diffResult)
+  const commands = ApplyRender.applyRender(oldState, scheduledState, diffResult)
+  if (!RendererProcess.isConnected()) return commands
+  return renderDirect(uid, commands)
+}
+
+const renderDirect = async (uid: number, commands: readonly any[]): Promise<readonly any[]> => {
+  const rendererWorkerCommands = commands.filter((command) => command[0] === 'Viewlet.setFocusContext')
+  const rendererProcessCommands = commands.filter((command) => command[0] !== 'Viewlet.setFocusContext')
+  const transactionId = await RendererProcess.invoke('Viewlet.queueCommands', uid, rendererProcessCommands)
+  return [...rendererWorkerCommands, ['Viewlet.commitPending', uid, transactionId]]
 }

--- a/packages/process-explorer-worker/src/parts/Render2/Render2.ts
+++ b/packages/process-explorer-worker/src/parts/Render2/Render2.ts
@@ -13,9 +13,23 @@ export const render2 = (
   return renderDirect(uid, commands)
 }
 
-const renderDirect = async (uid: number, commands: readonly any[]): Promise<readonly any[]> => {
-  const rendererWorkerCommands = commands.filter((command) => command[0] === 'Viewlet.setFocusContext')
-  const rendererProcessCommands = commands.filter((command) => command[0] !== 'Viewlet.setFocusContext')
-  const transactionId = await RendererProcess.invoke('Viewlet.queueCommands', uid, rendererProcessCommands)
-  return [...rendererWorkerCommands, ['Viewlet.commitPending', uid, transactionId]]
+const renderDirect = async (
+  uid: number,
+  commands: readonly any[],
+): Promise<readonly any[]> => {
+  const rendererWorkerCommands = commands.filter(
+    (command) => command[0] === 'Viewlet.setFocusContext',
+  )
+  const rendererProcessCommands = commands.filter(
+    (command) => command[0] !== 'Viewlet.setFocusContext',
+  )
+  const transactionId = await RendererProcess.invoke(
+    'Viewlet.queueCommands',
+    uid,
+    rendererProcessCommands,
+  )
+  return [
+    ...rendererWorkerCommands,
+    ['Viewlet.commitPending', uid, transactionId],
+  ]
 }

--- a/packages/process-explorer-worker/src/parts/RendererProcess/RendererProcess.ts
+++ b/packages/process-explorer-worker/src/parts/RendererProcess/RendererProcess.ts
@@ -1,0 +1,13 @@
+import type { Rpc } from '@lvce-editor/rpc'
+import { RendererProcess as RendererProcessRegistry } from '@lvce-editor/rpc-registry'
+
+const state = { connected: false }
+export const isConnected = (): boolean => {
+  const { connected } = state
+  return connected
+}
+export const invoke = (method: string, ...params: readonly unknown[]): Promise<any> => RendererProcessRegistry.invoke(method, ...params)
+export const set = (rpc: Rpc): void => {
+  RendererProcessRegistry.set(rpc)
+  state.connected = true
+}

--- a/packages/process-explorer-worker/src/parts/RendererProcess/RendererProcess.ts
+++ b/packages/process-explorer-worker/src/parts/RendererProcess/RendererProcess.ts
@@ -6,7 +6,10 @@ export const isConnected = (): boolean => {
   const { connected } = state
   return connected
 }
-export const invoke = (method: string, ...params: readonly unknown[]): Promise<any> => RendererProcessRegistry.invoke(method, ...params)
+export const invoke = (
+  method: string,
+  ...params: readonly unknown[]
+): Promise<any> => RendererProcessRegistry.invoke(method, ...params)
 export const set = (rpc: Rpc): void => {
   RendererProcessRegistry.set(rpc)
   state.connected = true

--- a/packages/process-explorer-worker/test/HandleMessagePort.test.ts
+++ b/packages/process-explorer-worker/test/HandleMessagePort.test.ts
@@ -1,0 +1,22 @@
+import { expect, jest, test } from '@jest/globals'
+import { PlainMessagePortRpcParent } from '@lvce-editor/rpc'
+import { RendererProcess as RendererProcessRegistry } from '@lvce-editor/rpc-registry'
+import { handleMessagePort } from '../src/parts/HandleMessagePort/HandleMessagePort.ts'
+import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
+
+test('connects the view directly to the renderer process', async () => {
+  const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 31)
+  const { port1, port2 } = new MessageChannel()
+  const rendererProcessRpc = await PlainMessagePortRpcParent.create({
+    commandMap: { 'Viewlet.queueCommands': queueCommands },
+    messagePort: port1,
+  })
+
+  await handleMessagePort(port2)
+  expect(RendererProcess.isConnected()).toBe(true)
+  await expect(RendererProcess.invoke('Viewlet.queueCommands', 7, [['Viewlet.setDom2', 7, []]])).resolves.toBe(31)
+  expect(queueCommands).toHaveBeenCalledWith(7, [['Viewlet.setDom2', 7, []]])
+
+  await RendererProcessRegistry.dispose()
+  await rendererProcessRpc.dispose()
+})

--- a/packages/process-explorer-worker/test/HandleMessagePort.test.ts
+++ b/packages/process-explorer-worker/test/HandleMessagePort.test.ts
@@ -5,7 +5,9 @@ import { handleMessagePort } from '../src/parts/HandleMessagePort/HandleMessageP
 import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
 
 test('connects the view directly to the renderer process', async () => {
-  const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 31)
+  const queueCommands = jest.fn(
+    (_uid: number, _commands: readonly unknown[]) => 31,
+  )
   const { port1, port2 } = new MessageChannel()
   const rendererProcessRpc = await PlainMessagePortRpcParent.create({
     commandMap: { 'Viewlet.queueCommands': queueCommands },
@@ -14,7 +16,11 @@ test('connects the view directly to the renderer process', async () => {
 
   await handleMessagePort(port2)
   expect(RendererProcess.isConnected()).toBe(true)
-  await expect(RendererProcess.invoke('Viewlet.queueCommands', 7, [['Viewlet.setDom2', 7, []]])).resolves.toBe(31)
+  await expect(
+    RendererProcess.invoke('Viewlet.queueCommands', 7, [
+      ['Viewlet.setDom2', 7, []],
+    ]),
+  ).resolves.toBe(31)
   expect(queueCommands).toHaveBeenCalledWith(7, [['Viewlet.setDom2', 7, []]])
 
   await RendererProcessRegistry.dispose()

--- a/packages/process-explorer-worker/test/Render2.test.ts
+++ b/packages/process-explorer-worker/test/Render2.test.ts
@@ -38,7 +38,7 @@ const processes = [
   },
 ]
 
-test('render2', () => {
+test('render2', async () => {
   ProcessExplorerStates.clear()
   const uid = 1
   const oldState = createDefaultState()
@@ -48,7 +48,7 @@ test('render2', () => {
   }
   ProcessExplorerStates.set(uid, oldState, newState)
   expect(Diff2.diff2(uid)).toEqual([DiffType.RenderIncremental])
-  const commands = Render2.render2(uid, [DiffType.RenderIncremental])
+  const commands = await Render2.render2(uid, [DiffType.RenderIncremental])
   expect(commands[0][0]).toBe(ViewletCommand.SetPatches)
   expect(ProcessExplorerStates.get(uid).oldState).toBe(newState)
 })


### PR DESCRIPTION
Route view render commands directly to the renderer process while retaining renderer-worker-only focus context updates. Adds focused coverage for the direct message-port connection.