### PR TITLE
feature: handle view events directly

### DIFF
--- a/packages/process-explorer-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/process-explorer-worker/src/parts/CommandMap/CommandMap.ts
@@ -32,6 +32,9 @@ import * as SetError from '../SetError/SetError.ts'
 import * as SetRootProcessId from '../SetRootProcessId/SetRootProcessId.ts'
 import * as SetUpdateInterval from '../SetUpdateInterval/SetUpdateInterval.ts'
 
+const handleDirectMessagePort = (port: MessagePort): Promise<void> =>
+  handleMessagePort(port, commandMap)
+
 export const commandMap = {
   'ProcessExplorer.collapseAll': ProcessExplorerStates.wrapCommand(
     CollapseAll.collapseAll,
@@ -89,7 +92,7 @@ export const commandMap = {
   'ProcessExplorer.handleFocus': ProcessExplorerStates.wrapCommand(
     HandleFocus.handleFocus,
   ),
-  'ProcessExplorer.handleMessagePort': handleMessagePort,
+  'ProcessExplorer.handleMessagePort': handleDirectMessagePort,
   'ProcessExplorer.killProcess': ProcessExplorerStates.wrapCommand(
     KillProcess.killProcess,
   ),

--- a/packages/process-explorer-worker/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/process-explorer-worker/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -1,9 +1,28 @@
 import { PlainMessagePortRpc } from '@lvce-editor/rpc'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 
-export const handleMessagePort = async (port: MessagePort): Promise<void> => {
+export const handleMessagePort = async (
+  port: MessagePort,
+  viewletCommandMap: Readonly<Record<string, unknown>>,
+): Promise<void> => {
+  const executeViewletCommand = async (
+    uid: number,
+    command: string,
+    ...args: readonly any[]
+  ): Promise<void> => {
+    const fn = viewletCommandMap[`ProcessExplorer.${command}`]
+    if (typeof fn !== 'function') {
+      throw new TypeError(`Viewlet command not found: ${command}`)
+    }
+    await fn(uid, ...args)
+    await RendererWorker.invoke('Viewlet.requestRender', uid)
+  }
+
   const rpc = await PlainMessagePortRpc.create({
-    commandMap: {},
+    commandMap: {
+      'Viewlet.executeViewletCommand': executeViewletCommand,
+    },
     messagePort: port,
   })
   RendererProcess.set(rpc)

--- a/packages/process-explorer-worker/test/HandleMessagePort.test.ts
+++ b/packages/process-explorer-worker/test/HandleMessagePort.test.ts
@@ -1,6 +1,9 @@
 import { expect, jest, test } from '@jest/globals'
-import { PlainMessagePortRpcParent } from '@lvce-editor/rpc'
-import { RendererProcess as RendererProcessRegistry } from '@lvce-editor/rpc-registry'
+import { createMockRpc, PlainMessagePortRpcParent } from '@lvce-editor/rpc'
+import {
+  RendererProcess as RendererProcessRegistry,
+  RendererWorker,
+} from '@lvce-editor/rpc-registry'
 import { handleMessagePort } from '../src/parts/HandleMessagePort/HandleMessagePort.ts'
 import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
 
@@ -13,8 +16,11 @@ test('connects the view directly to the renderer process', async () => {
     commandMap: { 'Viewlet.queueCommands': queueCommands },
     messagePort: port1,
   })
+  const handleEvent = jest.fn(async (_uid: number, _value: string) => {})
 
-  await handleMessagePort(port2)
+  await handleMessagePort(port2, {
+    'ProcessExplorer.handleEvent': handleEvent,
+  })
   expect(RendererProcess.isConnected()).toBe(true)
   await expect(
     RendererProcess.invoke('Viewlet.queueCommands', 7, [
@@ -23,6 +29,30 @@ test('connects the view directly to the renderer process', async () => {
   ).resolves.toBe(31)
   expect(queueCommands).toHaveBeenCalledWith(7, [['Viewlet.setDom2', 7, []]])
 
+  const requestRender = jest.fn(async (_uid: number) => {})
+  RendererWorker.set(
+    Object.assign(
+      createMockRpc({
+        commandMap: {
+          'Viewlet.requestRender': requestRender,
+        },
+      }),
+      { dispose: jest.fn() },
+    ),
+  )
+  await rendererProcessRpc.invoke(
+    'Viewlet.executeViewletCommand',
+    7,
+    'handleEvent',
+    'hello',
+  )
+  expect(handleEvent).toHaveBeenCalledWith(7, 'hello')
+  expect(requestRender).toHaveBeenCalledWith(7)
+  await expect(
+    rendererProcessRpc.invoke('Viewlet.executeViewletCommand', 7, 'missing'),
+  ).rejects.toThrow('Viewlet command not found: missing')
+
   await RendererProcessRegistry.dispose()
+  await RendererWorker.dispose()
   await rendererProcessRpc.dispose()
 })


### PR DESCRIPTION
## Summary
- expose direct renderer-process DOM event handling on the view port
- update view state in the owning worker and request a renderer-worker diff/render
- defer command-map capture until the direct port is connected

## Tests
- npm run type-check
- focused direct message-port test
- full repository test suite