### PR TITLE
feature: support secondary direct view connections

### DIFF
--- a/packages/process-explorer-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/process-explorer-worker/src/parts/CommandMap/CommandMap.ts
@@ -32,8 +32,10 @@ import * as SetError from '../SetError/SetError.ts'
 import * as SetRootProcessId from '../SetRootProcessId/SetRootProcessId.ts'
 import * as SetUpdateInterval from '../SetUpdateInterval/SetUpdateInterval.ts'
 
-const handleDirectMessagePort = (port: MessagePort): Promise<void> =>
-  handleMessagePort(port, commandMap)
+const handleDirectMessagePort = (
+  port: MessagePort,
+  setAsRendererProcess = true,
+): Promise<void> => handleMessagePort(port, commandMap, setAsRendererProcess)
 
 export const commandMap = {
   'ProcessExplorer.collapseAll': ProcessExplorerStates.wrapCommand(

--- a/packages/process-explorer-worker/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/process-explorer-worker/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -5,6 +5,7 @@ import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 export const handleMessagePort = async (
   port: MessagePort,
   viewletCommandMap: Readonly<Record<string, unknown>>,
+  setAsRendererProcess = true,
 ): Promise<void> => {
   const executeViewletCommand = async (
     uid: number,
@@ -25,5 +26,7 @@ export const handleMessagePort = async (
     },
     messagePort: port,
   })
-  RendererProcess.set(rpc)
+  if (setAsRendererProcess) {
+    RendererProcess.set(rpc)
+  }
 }

--- a/packages/process-explorer-worker/test/HandleMessagePort.test.ts
+++ b/packages/process-explorer-worker/test/HandleMessagePort.test.ts
@@ -56,3 +56,27 @@ test('connects the view directly to the renderer process', async () => {
   await RendererWorker.dispose()
   await rendererProcessRpc.dispose()
 })
+
+test('keeps the renderer process rpc for a secondary direct connection', async () => {
+  const queueCommands = jest.fn(
+    (_uid: number, _commands: readonly unknown[]) => 31,
+  )
+  RendererProcessRegistry.set(
+    Object.assign(
+      createMockRpc({
+        commandMap: { 'Viewlet.queueCommands': queueCommands },
+      }),
+      { dispose: jest.fn() },
+    ),
+  )
+  const { port1, port2 } = new MessageChannel()
+
+  await handleMessagePort(port2, {}, false)
+
+  expect(RendererProcess.invoke('Viewlet.queueCommands', 7, [])).toBe(31)
+  expect(queueCommands).toHaveBeenCalledWith(7, [])
+
+  port1.close()
+  port2.close()
+  await RendererProcessRegistry.dispose()
+})


### PR DESCRIPTION
## Summary
- accept a secondary direct MessagePort for Test Worker events
- preserve the existing Renderer Process RPC on secondary connections
- continue requesting render diffs through Renderer Worker

## Tests
- npm run type-check
- focused HandleMessagePort tests