### PR TITLE
fix: show process memory usage on macOS

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,6 +17,7 @@ export default defineConfig([
   },
   {
     files: [
+      'packages/process-explorer/test/ListProcessesWithMemoryUsageMacos.test.ts',
       'packages/process-explorer/test/ListProcessesWithMemoryUsageUnix.test.ts',
       'packages/process-explorer/test/ListProcessesWithMemoryUsageWindows.test.ts',
       'packages/process-explorer/test/E2eFixtureProcess.test.ts',

--- a/packages/process-explorer/src/parts/GetPsOutput/GetPsOutput.ts
+++ b/packages/process-explorer/src/parts/GetPsOutput/GetPsOutput.ts
@@ -10,7 +10,7 @@ export const getPsOutput = async (): Promise<string> => {
     const { stdout } = await execFile('ps', [
       '-ax',
       '-o',
-      'pid=,ppid=,pcpu=,pmem=,command=',
+      'pid=,ppid=,pcpu=,rss=,command=',
     ])
     return stdout.trim()
   } catch (error) {

--- a/packages/process-explorer/src/parts/ListProcessesWithMemoryUsageUnix/ListProcessesWithMemoryUsageUnix.ts
+++ b/packages/process-explorer/src/parts/ListProcessesWithMemoryUsageUnix/ListProcessesWithMemoryUsageUnix.ts
@@ -4,6 +4,7 @@ import * as AddAccurateMemoryUsage from '../AddAccurateMemoryUsage/AddAccurateMe
 import * as CreatePidMap from '../CreatePidMap/CreatePidMap.ts'
 import * as GetPsOutput from '../GetPsOutput/GetPsOutput.ts'
 import * as HasPositiveMemoryUsage from '../HasPositiveMemoryUsage/HasPositiveMemoryUsage.ts'
+import * as IsMacos from '../IsMacos/IsMacos.ts'
 import * as ParsePsOutput from '../ParsePsOutput/ParsePsOutput.ts'
 
 export const listProcessesWithMemoryUsage = async (
@@ -22,9 +23,11 @@ export const listProcessesWithMemoryUsage = async (
   const parsed = ParsePsOutput.parsePsOutput(stdout, rootPid, pidMap)
   // console.timeEnd('parsePsOutput')
   // console.time('addAccurateMemoryUsage')
-  const parsedWithAccurateMemoryUsage = await Promise.all(
-    parsed.map(AddAccurateMemoryUsage.addAccurateMemoryUsage),
-  )
+  const parsedWithAccurateMemoryUsage = IsMacos.isMacOs
+    ? parsed
+    : await Promise.all(
+        parsed.map(AddAccurateMemoryUsage.addAccurateMemoryUsage),
+      )
   // console.timeEnd('addAccurateMemoryUsage')
   const filtered = parsedWithAccurateMemoryUsage.filter(
     HasPositiveMemoryUsage.hasPositiveMemoryUsage,

--- a/packages/process-explorer/src/parts/ParsePsOutputLine/ParsePsOutputLine.ts
+++ b/packages/process-explorer/src/parts/ParsePsOutputLine/ParsePsOutputLine.ts
@@ -19,6 +19,7 @@ export const parsePsOutputLine = (line: string): ParsedPsLine => {
   ) {
     return {
       cmd,
+      memory: Number.parseInt(memoryField.value) * 1024,
       pid: Number.parseInt(pidField.value),
       ppid: Number.parseInt(ppidField.value),
     }

--- a/packages/process-explorer/src/parts/ParsedPsLine/ParsedPsLine.ts
+++ b/packages/process-explorer/src/parts/ParsedPsLine/ParsedPsLine.ts
@@ -1,5 +1,6 @@
 export interface ParsedPsLine {
   readonly cmd: string
+  readonly memory: number
   readonly pid: number
   readonly ppid: number
 }

--- a/packages/process-explorer/src/parts/ProcessItem/ProcessItem.ts
+++ b/packages/process-explorer/src/parts/ProcessItem/ProcessItem.ts
@@ -13,6 +13,7 @@ export interface ProcessItemWithDepth extends ProcessItem {
 export interface ParsedProcessItem {
   readonly cmd: string
   readonly depth: number
+  readonly memory: number
   readonly name: string
   readonly pid: number
   readonly ppid: number

--- a/packages/process-explorer/test/ListProcessesWithMemoryUsageMacos.test.ts
+++ b/packages/process-explorer/test/ListProcessesWithMemoryUsageMacos.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+jest.unstable_mockModule('node:child_process', () => ({
+  execFile: jest.fn(() => {
+    throw new Error('not implemented')
+  }),
+}))
+
+jest.unstable_mockModule('../src/parts/IsMacos/IsMacos.ts', () => ({
+  isMacOs: true,
+}))
+
+const createPidMap = jest.fn((): Record<string, never> => {
+  return {}
+})
+
+jest.unstable_mockModule('../src/parts/CreatePidMap/CreatePidMap.js', () => ({
+  createPidMap,
+}))
+
+const childProcess = await import('node:child_process')
+const ListProcessesWithMemoryUsage =
+  await import('../src/parts/ListProcessesWithMemoryUsageUnix/ListProcessesWithMemoryUsageUnix.js')
+
+test('listProcessesWithMemoryUsage - uses ps resident memory on macOS', async () => {
+  // @ts-ignore
+  childProcess.execFile.mockImplementation((command, args, callback) => {
+    callback(null, {
+      stdout: `100 1 0.0 2048 Electron
+101 100 0.0 4096 Electron Helper --type=renderer`,
+    })
+  })
+
+  await expect(
+    ListProcessesWithMemoryUsage.listProcessesWithMemoryUsage(100),
+  ).resolves.toEqual([
+    {
+      cmd: 'Electron',
+      depth: 1,
+      memory: 2_097_152,
+      name: 'main',
+      pid: 100,
+      ppid: 1,
+    },
+    {
+      cmd: 'Electron Helper --type=renderer',
+      depth: 2,
+      memory: 4_194_304,
+      name: 'renderer',
+      pid: 101,
+      ppid: 100,
+    },
+  ])
+  expect(childProcess.execFile).toHaveBeenCalledWith(
+    'ps',
+    ['-ax', '-o', 'pid=,ppid=,pcpu=,rss=,command='],
+    expect.any(Function),
+  )
+})

--- a/packages/process-explorer/test/ListProcessesWithMemoryUsageUnix.test.ts
+++ b/packages/process-explorer/test/ListProcessesWithMemoryUsageUnix.test.ts
@@ -12,7 +12,7 @@ jest.unstable_mockModule('node:child_process', () => ({
 }))
 
 jest.unstable_mockModule('../src/parts/IsMacos/IsMacos.ts', () => ({
-  isMacos: true,
+  isMacOs: false,
 }))
 
 jest.unstable_mockModule('node:path', () => ({

--- a/packages/process-explorer/test/ParsePsOutput.test.ts
+++ b/packages/process-explorer/test/ParsePsOutput.test.ts
@@ -12,7 +12,7 @@ test('parsePsOutput - linux', () => {
   2138    1442  0.0  0.0 /usr/libexec/gsd-sharing`
   const rootPid = 1442
   const pidMap = {}
-  expect(ParsePsOutput.parsePsOutput(output, rootPid, pidMap)).toEqual([
+  expect(ParsePsOutput.parsePsOutput(output, rootPid, pidMap)).toMatchObject([
     {
       cmd: '/usr/libexec/gsd-keyboard',
       depth: 1,
@@ -76,7 +76,7 @@ test('parsePsOutput - macos', () => {
   6353  6343   0.1  0.5 /Users/m1/Documents/lvce-editor/packages/main-process/node_modules/electron/dist/Electron.app/Contents/Frameworks/Electron Helper (Renderer).app/Contents/MacOS/Electron Helper (Renderer) --type=renderer --user-data-dir=/Users/m1/Library/Application Support/@lvce-editor/main-process --standard-schemes=lvce-oss --secure-schemes=lvce-oss --fetch-schemes=lvce-oss --streaming-schemes=lvce-oss --code-cache-schemes=lvce-oss --app-path=/Users/m1/Documents/lvce-editor/packages/main-process --enable-sandbox --lang=en --num-raster-threads=4 --enable-zero-copy --enable-gpu-memory-buffer-compositor-resources --enable-main-frame-before-activation --renderer-client-id=8 --time-ticks-at-unix-epoch=-1704110500487025 --launch-time-ticks=8985794256 --shared-files --field-trial-handle=1718379636,r,13753902317798746766,14167880203702055354,262144 --enable-features=kWebSQLAccess --disable-features=SpareRendererForSitePerProcess --variations-seed-version --lvce-window-kind=process-explorer --seatbelt-client=69`
   const rootPid = 6341
   const pidMap = {}
-  expect(ParsePsOutput.parsePsOutput(output, rootPid, pidMap)).toEqual([
+  expect(ParsePsOutput.parsePsOutput(output, rootPid, pidMap)).toMatchObject([
     {
       cmd: '/bin/bash ./scripts/run-electron.sh',
       depth: 1,
@@ -133,12 +133,25 @@ test('parsePsOutput - empty output', () => {
   expect(ParsePsOutput.parsePsOutput('', 1, {})).toEqual([])
 })
 
+test('parsePsOutput - parses resident memory in bytes', () => {
+  expect(ParsePsOutput.parsePsOutput('10 1 0.0 1234 root', 10, {})).toEqual([
+    {
+      cmd: 'root',
+      depth: 1,
+      memory: 1_263_616,
+      name: 'main',
+      pid: 10,
+      ppid: 1,
+    },
+  ])
+})
+
 test('parsePsOutput - skips process without known parent depth', () => {
   const output = `10 1 0.0 0.1 root
 20 999 0.0 0.1 orphan
 30 10 0.0 0.1 child`
 
-  expect(ParsePsOutput.parsePsOutput(output, 10, {})).toEqual([
+  expect(ParsePsOutput.parsePsOutput(output, 10, {})).toMatchObject([
     {
       cmd: 'root',
       depth: 1,


### PR DESCRIPTION
Fix Process Explorer memory reporting on macOS by collecting RSS in the existing process-list query and converting it to bytes. Linux continues to use /proc for its more accurate measurement. Adds regression coverage for the Darwin path.