### PR TITLE
fix: display process explorer error codes

### DIFF
--- a/packages/e2e/src/viewlet.process-explorer.error.ts
+++ b/packages/e2e/src/viewlet.process-explorer.error.ts
@@ -31,6 +31,7 @@ export const test: Test = async ({ Command, expect, Locator }) => {
   try {
     await expect(error).toBeVisible()
     await expect(table).toBeHidden()
+    await expect(error).toContainText('ERR_PROCESS_EXPLORER_E2E')
     await expect(error).toContainText(fixtureMessage)
     await expect(error).toContainText(fixtureThrowLine)
     await expect(error).toContainText(stackLine)

--- a/packages/process-explorer-worker/src/parts/Create/Create.ts
+++ b/packages/process-explorer-worker/src/parts/Create/Create.ts
@@ -41,6 +41,7 @@ export const create = (
   const state: ProcessExplorerState = {
     assetDir,
     collapsedPids: [],
+    errorCode: '',
     errorCodeFrame: '',
     errorMessage: '',
     errorStack: '',

--- a/packages/process-explorer-worker/src/parts/CreateDefaultState/CreateDefaultState.ts
+++ b/packages/process-explorer-worker/src/parts/CreateDefaultState/CreateDefaultState.ts
@@ -4,6 +4,7 @@ import * as ProcessExplorerUpdateInterval from '../ProcessExplorerUpdateInterval
 export const createDefaultState = (): ProcessExplorerState => ({
   assetDir: '',
   collapsedPids: [],
+  errorCode: '',
   errorCodeFrame: '',
   errorMessage: '',
   errorStack: '',

--- a/packages/process-explorer-worker/src/parts/DiffItems/DiffItems.ts
+++ b/packages/process-explorer-worker/src/parts/DiffItems/DiffItems.ts
@@ -6,6 +6,7 @@ export const isEqual = (
 ): boolean => {
   return (
     oldState.initial === newState.initial &&
+    oldState.errorCode === newState.errorCode &&
     oldState.errorCodeFrame === newState.errorCodeFrame &&
     oldState.errorMessage === newState.errorMessage &&
     oldState.errorStack === newState.errorStack &&

--- a/packages/process-explorer-worker/src/parts/ErrorCodes/ErrorCodes.ts
+++ b/packages/process-explorer-worker/src/parts/ErrorCodes/ErrorCodes.ts
@@ -1,0 +1,6 @@
+export const ProcessExplorerError = 'E_PROCESS_EXPLORER_ERROR'
+
+export const ProcessExplorerRefreshFailed = 'E_PROCESS_EXPLORER_REFRESH_FAILED'
+
+export const ProcessExplorerRpcConnectionClosed =
+  'E_PROCESS_EXPLORER_RPC_CONNECTION_CLOSED'

--- a/packages/process-explorer-worker/src/parts/GetErrorCode/GetErrorCode.ts
+++ b/packages/process-explorer-worker/src/parts/GetErrorCode/GetErrorCode.ts
@@ -1,0 +1,10 @@
+export const getErrorCode = (error: unknown, fallback: string): string => {
+  if (!error || typeof error !== 'object') {
+    return fallback
+  }
+  const code = 'code' in error ? error.code : undefined
+  if (typeof code !== 'string' || !code) {
+    return fallback
+  }
+  return code
+}

--- a/packages/process-explorer-worker/src/parts/HandleProcessExplorerRpcClose/HandleProcessExplorerRpcClose.ts
+++ b/packages/process-explorer-worker/src/parts/HandleProcessExplorerRpcClose/HandleProcessExplorerRpcClose.ts
@@ -1,6 +1,7 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import type { ProcessExplorerState } from '../ProcessExplorerState/ProcessExplorerState.ts'
 import * as AutoRefresh from '../AutoRefresh/AutoRefresh.ts'
+import * as ErrorCodes from '../ErrorCodes/ErrorCodes.ts'
 import * as ProcessExplorerStates from '../ProcessExplorerStates/ProcessExplorerStates.ts'
 
 export const processExplorerRpcClosedMessage =
@@ -11,6 +12,7 @@ export const toProcessExplorerRpcClosedState = (
 ): ProcessExplorerState => {
   return {
     ...state,
+    errorCode: ErrorCodes.ProcessExplorerRpcConnectionClosed,
     errorCodeFrame: '',
     errorMessage: processExplorerRpcClosedMessage,
     errorStack: '',

--- a/packages/process-explorer-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/process-explorer-worker/src/parts/LoadContent/LoadContent.ts
@@ -4,7 +4,12 @@ import * as AutoRefresh from '../AutoRefresh/AutoRefresh.ts'
 import * as Refresh from '../Refresh/Refresh.ts'
 
 const hasError = (state: ProcessExplorerState): boolean => {
-  return Boolean(state.errorMessage || state.errorCodeFrame || state.errorStack)
+  return Boolean(
+    state.errorCode ||
+    state.errorMessage ||
+    state.errorCodeFrame ||
+    state.errorStack,
+  )
 }
 
 export const loadContent = async (

--- a/packages/process-explorer-worker/src/parts/ProcessExplorerState/ProcessExplorerState.ts
+++ b/packages/process-explorer-worker/src/parts/ProcessExplorerState/ProcessExplorerState.ts
@@ -4,6 +4,7 @@ import type { VisibleProcess } from '../VisibleProcess/VisibleProcess.ts'
 export interface ProcessExplorerState {
   readonly assetDir: string
   readonly collapsedPids: readonly number[]
+  readonly errorCode: string
   readonly errorCodeFrame: string
   readonly errorMessage: string
   readonly errorStack: string

--- a/packages/process-explorer-worker/src/parts/Refresh/Refresh.ts
+++ b/packages/process-explorer-worker/src/parts/Refresh/Refresh.ts
@@ -2,6 +2,8 @@ import { PlatformType } from '@lvce-editor/constants'
 import { MainProcess } from '@lvce-editor/rpc-registry'
 import type { ProcessExplorerState } from '../ProcessExplorerState/ProcessExplorerState.ts'
 import type { ProcessInfo } from '../ProcessInfo/ProcessInfo.ts'
+import * as ErrorCodes from '../ErrorCodes/ErrorCodes.ts'
+import * as GetErrorCode from '../GetErrorCode/GetErrorCode.ts'
 import * as GetFrontendMemoryUsage from '../GetFrontendMemoryUsage/GetFrontendMemoryUsage.ts'
 import * as GetVisibleProcesses from '../GetVisibleProcesses/GetVisibleProcesses.ts'
 import * as InitializeProcessExplorer from '../InitializeProcessExplorer/InitializeProcessExplorer.ts'
@@ -72,6 +74,7 @@ export const refresh = async (
     )
     return {
       ...state,
+      errorCode: '',
       errorCodeFrame: '',
       errorMessage: '',
       errorStack: '',
@@ -85,6 +88,10 @@ export const refresh = async (
     const prettyError = await PrepareError.prepareError(error)
     return {
       ...state,
+      errorCode: GetErrorCode.getErrorCode(
+        error,
+        ErrorCodes.ProcessExplorerRefreshFailed,
+      ),
       errorCodeFrame: prettyError.codeFrame || '',
       errorMessage: prettyError.message || PrepareError.getErrorMessage(error),
       errorStack: prettyError.stack || '',

--- a/packages/process-explorer-worker/src/parts/RenderItems/RenderItems.ts
+++ b/packages/process-explorer-worker/src/parts/RenderItems/RenderItems.ts
@@ -164,14 +164,15 @@ const getErrorSectionDom = (
 }
 
 const hasError = (state: ProcessExplorerState): boolean => {
-  const { errorCodeFrame, errorMessage, errorStack } = state
-  return Boolean(errorMessage || errorCodeFrame || errorStack)
+  const { errorCode, errorCodeFrame, errorMessage, errorStack } = state
+  return Boolean(errorCode || errorMessage || errorCodeFrame || errorStack)
 }
 
 const getErrorDom = (
   state: ProcessExplorerState,
 ): readonly VirtualDomNode[] => {
-  const { errorCodeFrame, errorMessage, errorStack } = state
+  const { errorCode, errorCodeFrame, errorMessage, errorStack } = state
+  const errorCodeDom = getErrorSectionDom(errorCode, VirtualDomElements.Div)
   const messageDom = getErrorSectionDom(errorMessage, VirtualDomElements.Div)
   const codeFrameDom = getErrorSectionDom(
     errorCodeFrame,
@@ -179,7 +180,10 @@ const getErrorDom = (
   )
   const stackDom = getErrorSectionDom(errorStack, VirtualDomElements.Pre)
   const childCount =
-    messageDom.length / 2 + codeFrameDom.length / 2 + stackDom.length / 2
+    errorCodeDom.length / 2 +
+    messageDom.length / 2 +
+    codeFrameDom.length / 2 +
+    stackDom.length / 2
   return [
     processExplorer,
     {
@@ -187,6 +191,7 @@ const getErrorDom = (
       className: ClassNames.Error,
       type: VirtualDomElements.Div,
     },
+    ...errorCodeDom,
     ...messageDom,
     ...codeFrameDom,
     ...stackDom,

--- a/packages/process-explorer-worker/src/parts/SetError/SetError.ts
+++ b/packages/process-explorer-worker/src/parts/SetError/SetError.ts
@@ -1,4 +1,6 @@
 import type { ProcessExplorerState } from '../ProcessExplorerState/ProcessExplorerState.ts'
+import * as ErrorCodes from '../ErrorCodes/ErrorCodes.ts'
+import * as GetErrorCode from '../GetErrorCode/GetErrorCode.ts'
 import * as PrepareError from '../PrepareError/PrepareError.ts'
 
 interface RawError {
@@ -49,6 +51,10 @@ export const setError = async (
   const prettyError = await PrepareError.prepareError(error)
   return {
     ...state,
+    errorCode: GetErrorCode.getErrorCode(
+      error,
+      ErrorCodes.ProcessExplorerError,
+    ),
     errorCodeFrame: prettyError.codeFrame || '',
     errorMessage: prettyError.message || PrepareError.getErrorMessage(error),
     errorStack: prettyError.stack || '',

--- a/packages/process-explorer-worker/test/CreateDefaultState.test.ts
+++ b/packages/process-explorer-worker/test/CreateDefaultState.test.ts
@@ -5,6 +5,7 @@ test('createDefaultState', () => {
   expect(createDefaultState()).toMatchObject({
     assetDir: '',
     collapsedPids: [],
+    errorCode: '',
     errorCodeFrame: '',
     errorMessage: '',
     errorStack: '',

--- a/packages/process-explorer-worker/test/GetErrorCode.test.ts
+++ b/packages/process-explorer-worker/test/GetErrorCode.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@jest/globals'
+import * as GetErrorCode from '../src/parts/GetErrorCode/GetErrorCode.ts'
+
+const fallback = 'E_PROCESS_EXPLORER_ERROR'
+
+test('getErrorCode - returns error code', () => {
+  expect(GetErrorCode.getErrorCode({ code: 'ERR_TEST' }, fallback)).toBe(
+    'ERR_TEST',
+  )
+})
+
+test('getErrorCode - returns fallback for missing error code', () => {
+  expect(GetErrorCode.getErrorCode(new Error('test'), fallback)).toBe(fallback)
+})
+
+test('getErrorCode - returns fallback for empty error code', () => {
+  expect(GetErrorCode.getErrorCode({ code: '' }, fallback)).toBe(fallback)
+})
+
+test('getErrorCode - returns fallback for non-string error code', () => {
+  expect(GetErrorCode.getErrorCode({ code: 1 }, fallback)).toBe(fallback)
+})
+
+test('getErrorCode - returns fallback for primitive error', () => {
+  expect(GetErrorCode.getErrorCode('test', fallback)).toBe(fallback)
+})

--- a/packages/process-explorer-worker/test/HandleProcessExplorerRpcClose.test.ts
+++ b/packages/process-explorer-worker/test/HandleProcessExplorerRpcClose.test.ts
@@ -32,6 +32,7 @@ test('handleProcessExplorerRpcClose - displays an error and stops refreshing', a
   await jest.advanceTimersByTimeAsync(100)
 
   expect(ProcessExplorerStates.get(7).scheduledState).toMatchObject({
+    errorCode: 'E_PROCESS_EXPLORER_RPC_CONNECTION_CLOSED',
     errorCodeFrame: '',
     errorMessage: HandleProcessExplorerRpcClose.processExplorerRpcClosedMessage,
     errorStack: '',

--- a/packages/process-explorer-worker/test/ProcessCommands.test.ts
+++ b/packages/process-explorer-worker/test/ProcessCommands.test.ts
@@ -83,6 +83,7 @@ test('killProcess - does not wait for process explorer rpc response', async () =
   }
 
   await expect(KillProcess.killProcess(state, 0)).resolves.toMatchObject({
+    errorCode: 'E_PROCESS_EXPLORER_RPC_CONNECTION_CLOSED',
     errorCodeFrame: '',
     errorMessage: 'Process explorer RPC connection was closed',
     errorStack: '',

--- a/packages/process-explorer-worker/test/Refresh.test.ts
+++ b/packages/process-explorer-worker/test/Refresh.test.ts
@@ -346,10 +346,31 @@ test('refresh - error', async () => {
   const result = await Refresh.refresh(createDefaultState())
   expect(prepare).toHaveBeenCalledTimes(1)
   expect(prepare.mock.calls[0][0]).toBeInstanceOf(Error)
+  expect(result.errorCode).toBe('E_PROCESS_EXPLORER_REFRESH_FAILED')
   expect(result.errorCodeFrame).toBe('1 | throw new Error()')
   expect(result.errorMessage).toBe('Pretty no pid')
   expect(result.errorStack).toBe('Pretty stack')
   expect(result.initial).toBe(false)
+})
+
+test('refresh - preserves error code', async () => {
+  using _mockRpc = registerProcessExplorerMock({
+    'ProcessId.getMainProcessId': jest.fn(() => {
+      throw Object.assign(new Error('no pid'), { code: 'ERR_NO_PID' })
+    }),
+  })
+  using _mockErrorRpc = registerErrorWorkerMock({
+    'Errors.prepare': jest.fn(() => ({
+      codeFrame: undefined,
+      message: 'Pretty no pid',
+      stack: undefined,
+    })),
+  })
+
+  const result = await Refresh.refresh(createDefaultState())
+
+  expect(result.errorCode).toBe('ERR_NO_PID')
+  expect(result.errorMessage).toBe('Pretty no pid')
 })
 
 test('refresh - error prepare fails', async () => {
@@ -364,6 +385,7 @@ test('refresh - error prepare fails', async () => {
     }),
   })
   const result = await Refresh.refresh(createDefaultState())
+  expect(result.errorCode).toBe('E_PROCESS_EXPLORER_REFRESH_FAILED')
   expect(result.errorCodeFrame).toBe('')
   expect(result.errorMessage).toBe('no pid')
   expect(result.errorStack).toBe('')
@@ -382,6 +404,7 @@ test('refresh - non error prepare fails', async () => {
     }),
   })
   const result = await Refresh.refresh(createDefaultState())
+  expect(result.errorCode).toBe('E_PROCESS_EXPLORER_REFRESH_FAILED')
   expect(result.errorCodeFrame).toBe('')
   expect(result.errorMessage).toBe('no pid')
   expect(result.errorStack).toBe('')

--- a/packages/process-explorer-worker/test/RenderItems.test.ts
+++ b/packages/process-explorer-worker/test/RenderItems.test.ts
@@ -175,6 +175,7 @@ test('renderItems - initial is empty', () => {
 test('renderItems - error only', () => {
   const state = {
     ...createDefaultState(),
+    errorCode: 'E_PROCESS_EXPLORER_REFRESH_FAILED',
     errorCodeFrame: '1 | throw new Error()',
     errorMessage: 'Pretty no pid',
     errorStack: 'Pretty stack',
@@ -187,6 +188,12 @@ test('renderItems - error only', () => {
     expect.objectContaining({
       className: 'ProcessExplorerError',
       type: VirtualDomElements.Div,
+    }),
+  )
+  expect(result[2]).toContainEqual(
+    expect.objectContaining({
+      text: 'E_PROCESS_EXPLORER_REFRESH_FAILED',
+      type: VirtualDomElements.Text,
     }),
   )
   expect(result[2]).toContainEqual(

--- a/packages/process-explorer-worker/test/SetError.test.ts
+++ b/packages/process-explorer-worker/test/SetError.test.ts
@@ -41,8 +41,18 @@ test('setError', async () => {
     message: 'Fixture error',
     stack: 'Error: Fixture error\n    at fixture (/tmp/fixture.ts:1:1)',
   })
+  expect(result.errorCode).toBe('ERR_TEST')
   expect(result.errorCodeFrame).toBe('1 | throw new Error()')
   expect(result.errorMessage).toBe('Pretty fixture error')
   expect(result.errorStack).toBe('Pretty stack')
   expect(result.initial).toBe(false)
+})
+
+test('setError - uses fallback code', async () => {
+  using _mockErrorRpc = registerErrorWorkerMock({})
+
+  const result = await SetError.setError(createDefaultState(), 'Fixture error')
+
+  expect(result.errorCode).toBe('E_PROCESS_EXPLORER_ERROR')
+  expect(result.errorMessage).toBe('Fixture error')
 })


### PR DESCRIPTION
Display a stable error code alongside every Process Explorer error message. Preserve upstream error codes and identify RPC connection closure with E_PROCESS_EXPLORER_RPC_CONNECTION_CLOSED.