### PR TITLE
fix: show local and remote processes

### DIFF
--- a/packages/process-explorer-worker/src/parts/CollapseAll/CollapseAll.ts
+++ b/packages/process-explorer-worker/src/parts/CollapseAll/CollapseAll.ts
@@ -4,13 +4,13 @@ import * as GetVisibleProcesses from '../GetVisibleProcesses/GetVisibleProcesses
 export const collapseAll = (
   state: ProcessExplorerState,
 ): ProcessExplorerState => {
-  const parentPids = new Set<number>()
+  const parentPids = new Set<number | string>()
   for (const process of state.processes) {
-    parentPids.add(process.ppid)
+    parentPids.add(process.parentTreeId ?? process.ppid)
   }
   const collapsedPids = state.processes
-    .filter((process) => parentPids.has(process.pid))
-    .map((process) => process.pid)
+    .filter((process) => parentPids.has(process.treeId ?? process.pid))
+    .map((process) => process.treeId ?? process.pid)
   const visibleProcesses = GetVisibleProcesses.getVisibleProcesses(
     state.processes,
     collapsedPids,

--- a/packages/process-explorer-worker/src/parts/ExpandAll/ExpandAll.ts
+++ b/packages/process-explorer-worker/src/parts/ExpandAll/ExpandAll.ts
@@ -4,7 +4,7 @@ import * as GetVisibleProcesses from '../GetVisibleProcesses/GetVisibleProcesses
 export const expandAll = (
   state: ProcessExplorerState,
 ): ProcessExplorerState => {
-  const collapsedPids: readonly number[] = []
+  const collapsedPids: readonly (number | string)[] = []
   const visibleProcesses = GetVisibleProcesses.getVisibleProcesses(
     state.processes,
     collapsedPids,

--- a/packages/process-explorer-worker/src/parts/GetMenuEntries/GetMenuEntries.ts
+++ b/packages/process-explorer-worker/src/parts/GetMenuEntries/GetMenuEntries.ts
@@ -8,7 +8,7 @@ export const getMenuEntries = (
   state: ProcessExplorerState,
 ): readonly MenuEntry[] => {
   const process = state.visibleProcesses[state.focusedIndex]
-  if (!process) {
+  if (!process || process.synthetic) {
     return []
   }
   const menuEntries: MenuEntry[] = [

--- a/packages/process-explorer-worker/src/parts/GetVisibleProcesses/GetVisibleProcesses.ts
+++ b/packages/process-explorer-worker/src/parts/GetVisibleProcesses/GetVisibleProcesses.ts
@@ -2,36 +2,51 @@ import type { ProcessInfo } from '../ProcessInfo/ProcessInfo.ts'
 import type { VisibleProcess } from '../VisibleProcess/VisibleProcess.ts'
 import * as ProcessFlag from '../ProcessFlag/ProcessFlag.ts'
 
-const getRootProcess = (
+const getTreeId = (process: ProcessInfo): number | string => {
+  return process.treeId ?? process.pid
+}
+
+const getParentTreeId = (process: ProcessInfo): number | string => {
+  return process.parentTreeId ?? process.ppid
+}
+
+const getRootProcesses = (
   processes: readonly ProcessInfo[],
   rootPid: number,
-): ProcessInfo | undefined => {
-  if (rootPid) {
-    return processes.find((process) => process.pid === rootPid)
+): readonly ProcessInfo[] => {
+  const groupedProcesses = processes.filter(
+    (process) => process.parentTreeId === '',
+  )
+  if (groupedProcesses.length > 0) {
+    return groupedProcesses
   }
-  return processes[0]
+  if (rootPid) {
+    const rootProcess = processes.find((process) => process.pid === rootPid)
+    return rootProcess ? [rootProcess] : []
+  }
+  return processes.length > 0 ? [processes[0]] : []
 }
 
 const hasChildren = (
   processes: readonly ProcessInfo[],
-  pid: number,
+  pid: number | string,
 ): boolean => {
-  return processes.some((process) => process.ppid === pid)
+  return processes.some((process) => getParentTreeId(process) === pid)
 }
 
 const getChildren = (
   processes: readonly ProcessInfo[],
-  collapsedPids: readonly number[],
+  collapsedPids: readonly (number | string)[],
   process: ProcessInfo,
   depth: number,
 ): readonly VisibleProcess[] => {
   const children = processes.filter(
-    (otherProcess) => otherProcess.ppid === process.pid,
+    (otherProcess) => getParentTreeId(otherProcess) === getTreeId(process),
   )
   if (children.length === 0) {
     return []
   }
-  if (collapsedPids.includes(process.pid)) {
+  if (collapsedPids.includes(getTreeId(process))) {
     return []
   }
   return children.flatMap((child) =>
@@ -41,13 +56,14 @@ const getChildren = (
 
 const withChildren = (
   processes: readonly ProcessInfo[],
-  collapsedPids: readonly number[],
+  collapsedPids: readonly (number | string)[],
   process: ProcessInfo,
   depth: number,
 ): readonly VisibleProcess[] => {
-  const processHasChildren = hasChildren(processes, process.pid)
+  const treeId = getTreeId(process)
+  const processHasChildren = hasChildren(processes, treeId)
   let flags = ProcessFlag.None
-  if (processHasChildren && collapsedPids.includes(process.pid)) {
+  if (processHasChildren && collapsedPids.includes(treeId)) {
     flags = ProcessFlag.Collapsed
   } else if (processHasChildren) {
     flags = ProcessFlag.Expanded
@@ -65,12 +81,11 @@ const withChildren = (
 
 export const getVisibleProcesses = (
   processes: readonly ProcessInfo[],
-  collapsedPids: readonly number[],
+  collapsedPids: readonly (number | string)[],
   rootPid: number,
 ): readonly VisibleProcess[] => {
-  const rootProcess = getRootProcess(processes, rootPid)
-  if (!rootProcess) {
-    return []
-  }
-  return withChildren(processes, collapsedPids, rootProcess, 1)
+  const rootProcesses = getRootProcesses(processes, rootPid)
+  return rootProcesses.flatMap((rootProcess) =>
+    withChildren(processes, collapsedPids, rootProcess, 1),
+  )
 }

--- a/packages/process-explorer-worker/src/parts/GroupProcesses/GroupProcesses.ts
+++ b/packages/process-explorer-worker/src/parts/GroupProcesses/GroupProcesses.ts
@@ -1,0 +1,41 @@
+import type { ProcessInfo } from '../ProcessInfo/ProcessInfo.ts'
+
+const createGroup = (
+  name: string,
+  source: 'local' | 'remote',
+  processes: readonly ProcessInfo[],
+  rootPid: number,
+): readonly ProcessInfo[] => {
+  const groupId = `${source}:group`
+  const group: ProcessInfo = {
+    cmd: name,
+    memory: 0,
+    name,
+    parentTreeId: '',
+    pid: 0,
+    ppid: 0,
+    source,
+    synthetic: true,
+    treeId: groupId,
+  }
+  const groupedProcesses = processes.map((process) => ({
+    ...process,
+    parentTreeId:
+      process.pid === rootPid ? groupId : `${source}:${process.ppid}`,
+    source,
+    treeId: `${source}:${process.pid}`,
+  }))
+  return [group, ...groupedProcesses]
+}
+
+export const groupProcesses = (
+  localProcesses: readonly ProcessInfo[],
+  localRootPid: number,
+  remoteProcesses: readonly ProcessInfo[],
+  remoteRootPid: number,
+): readonly ProcessInfo[] => {
+  return [
+    ...createGroup('Local', 'local', localProcesses, localRootPid),
+    ...createGroup('Remote', 'remote', remoteProcesses, remoteRootPid),
+  ]
+}

--- a/packages/process-explorer-worker/src/parts/InitializeProcessExplorer/InitializeProcessExplorer.ts
+++ b/packages/process-explorer-worker/src/parts/InitializeProcessExplorer/InitializeProcessExplorer.ts
@@ -1,16 +1,19 @@
 import { PlatformType } from '@lvce-editor/constants'
-import { MainProcess } from '@lvce-editor/rpc-registry'
+import { MainProcess, RendererWorker } from '@lvce-editor/rpc-registry'
 import * as HandleProcessExplorerRpcClose from '../HandleProcessExplorerRpcClose/HandleProcessExplorerRpcClose.ts'
 import * as LaunchProcessExplorerElectron from '../LaunchProcessExplorerElectron/LaunchProcessExplorerElectron.ts'
 import * as LaunchProcessExplorerNode from '../LaunchProcessExplorerNode/LaunchProcessExplorerNode.ts'
 import * as ProcessExplorerModule from '../ProcessExplorer/ProcessExplorer.ts'
+import * as RemoteProcessExplorer from '../RemoteProcessExplorer/RemoteProcessExplorer.ts'
 
 interface State {
   initializedPlatform: number
+  remoteInitialized: boolean
 }
 
 const state: State = {
   initializedPlatform: 0,
+  remoteInitialized: false,
 }
 
 const handleClose = async (): Promise<void> => {
@@ -19,10 +22,51 @@ const handleClose = async (): Promise<void> => {
   await HandleProcessExplorerRpcClose.handleProcessExplorerRpcClose()
 }
 
+const handleRemoteClose = (): void => {
+  state.remoteInitialized = false
+  RemoteProcessExplorer.clear()
+  void RendererWorker.invoke('ProcessExplorer.update').catch(() => {})
+}
+
+const isRemoteWorkspace = async (): Promise<boolean> => {
+  try {
+    return await RendererWorker.invoke('WebSocketCapability.isActive')
+  } catch {
+    return false
+  }
+}
+
+const initializeRemoteProcessExplorer = async (): Promise<void> => {
+  const remoteWorkspace = await isRemoteWorkspace()
+  if (!remoteWorkspace) {
+    if (state.remoteInitialized) {
+      state.remoteInitialized = false
+      await RemoteProcessExplorer.dispose()
+    }
+    return
+  }
+  if (state.remoteInitialized) {
+    return
+  }
+  try {
+    const remoteRpc =
+      await LaunchProcessExplorerNode.launchProcessExplorerNode(
+        handleRemoteClose,
+      )
+    RemoteProcessExplorer.set(remoteRpc)
+    state.remoteInitialized = true
+  } catch {
+    RemoteProcessExplorer.clear()
+  }
+}
+
 export const initializeProcessExplorer = async (
   platform: number,
 ): Promise<void> => {
   if (state.initializedPlatform === platform) {
+    if (platform === PlatformType.Electron) {
+      await initializeRemoteProcessExplorer()
+    }
     return
   }
   if (platform === PlatformType.Electron) {
@@ -31,6 +75,7 @@ export const initializeProcessExplorer = async (
     MainProcess.set(mainProcessRpc)
     ProcessExplorerModule.set(processExplorerRpc)
     state.initializedPlatform = platform
+    await initializeRemoteProcessExplorer()
     return
   }
   if (platform === PlatformType.Remote) {
@@ -46,14 +91,24 @@ export const initializeProcessExplorer = async (
 
 export const clear = (): void => {
   state.initializedPlatform = 0
+  state.remoteInitialized = false
+  RemoteProcessExplorer.clear()
 }
 
 export const dispose = async (): Promise<void> => {
   const { initializedPlatform } = state
   state.initializedPlatform = 0
+  state.remoteInitialized = false
   if (initializedPlatform === PlatformType.Electron) {
-    await Promise.all([MainProcess.dispose(), ProcessExplorerModule.dispose()])
+    await Promise.all([
+      MainProcess.dispose(),
+      ProcessExplorerModule.dispose(),
+      RemoteProcessExplorer.dispose(),
+    ])
     return
   }
-  await ProcessExplorerModule.dispose()
+  await Promise.all([
+    ProcessExplorerModule.dispose(),
+    RemoteProcessExplorer.dispose(),
+  ])
 }

--- a/packages/process-explorer-worker/src/parts/KillProcess/KillProcess.ts
+++ b/packages/process-explorer-worker/src/parts/KillProcess/KillProcess.ts
@@ -2,16 +2,19 @@ import type { ProcessExplorerState } from '../ProcessExplorerState/ProcessExplor
 import * as AutoRefresh from '../AutoRefresh/AutoRefresh.ts'
 import * as HandleProcessExplorerRpcClose from '../HandleProcessExplorerRpcClose/HandleProcessExplorerRpcClose.ts'
 import * as ProcessExplorer from '../ProcessExplorer/ProcessExplorer.ts'
+import * as RemoteProcessExplorer from '../RemoteProcessExplorer/RemoteProcessExplorer.ts'
 
 export const killProcess = async (
   state: ProcessExplorerState,
   index: number = state.focusedIndex,
 ): Promise<ProcessExplorerState> => {
   const process = state.visibleProcesses[index]
-  if (!process) {
+  if (!process || process.synthetic) {
     return state
   }
-  const killPromise = ProcessExplorer.invoke('Process.kill', process.pid)
+  const processExplorer =
+    process.source === 'remote' ? RemoteProcessExplorer : ProcessExplorer
+  const killPromise = processExplorer.invoke('Process.kill', process.pid)
   if (process.name === 'process-explorer') {
     AutoRefresh.dispose(state.uid)
     void killPromise.catch(() => {})

--- a/packages/process-explorer-worker/src/parts/ProcessExplorerState/ProcessExplorerState.ts
+++ b/packages/process-explorer-worker/src/parts/ProcessExplorerState/ProcessExplorerState.ts
@@ -3,7 +3,7 @@ import type { VisibleProcess } from '../VisibleProcess/VisibleProcess.ts'
 
 export interface ProcessExplorerState {
   readonly assetDir: string
-  readonly collapsedPids: readonly number[]
+  readonly collapsedPids: readonly (number | string)[]
   readonly errorCodeFrame: string
   readonly errorMessage: string
   readonly errorStack: string

--- a/packages/process-explorer-worker/src/parts/ProcessInfo/ProcessInfo.ts
+++ b/packages/process-explorer-worker/src/parts/ProcessInfo/ProcessInfo.ts
@@ -2,7 +2,10 @@ export interface ProcessInfo {
   readonly cmd: string
   readonly memory: number
   readonly name: string
+  readonly parentTreeId?: number | string
   readonly pid: number
   readonly ppid: number
+  readonly source?: 'local' | 'remote'
   readonly synthetic?: true
+  readonly treeId?: number | string
 }

--- a/packages/process-explorer-worker/src/parts/Refresh/Refresh.ts
+++ b/packages/process-explorer-worker/src/parts/Refresh/Refresh.ts
@@ -4,10 +4,19 @@ import type { ProcessExplorerState } from '../ProcessExplorerState/ProcessExplor
 import type { ProcessInfo } from '../ProcessInfo/ProcessInfo.ts'
 import * as GetFrontendMemoryUsage from '../GetFrontendMemoryUsage/GetFrontendMemoryUsage.ts'
 import * as GetVisibleProcesses from '../GetVisibleProcesses/GetVisibleProcesses.ts'
+import * as GroupProcesses from '../GroupProcesses/GroupProcesses.ts'
 import * as InitializeProcessExplorer from '../InitializeProcessExplorer/InitializeProcessExplorer.ts'
 import * as PrepareError from '../PrepareError/PrepareError.ts'
 import * as ProcessExplorerModule from '../ProcessExplorer/ProcessExplorer.ts'
+import * as RemoteProcessExplorer from '../RemoteProcessExplorer/RemoteProcessExplorer.ts'
 import * as ReparentSharedProcessChildren from '../ReparentSharedProcessChildren/ReparentSharedProcessChildren.ts'
+
+interface ProcessExplorerRpc {
+  readonly invoke: (
+    method: string,
+    ...params: readonly unknown[]
+  ) => Promise<any>
+}
 
 const getFocusedIndex = (
   oldFocusedIndex: number,
@@ -23,23 +32,36 @@ const getFocusedIndex = (
 }
 
 const listProcesses = async (
+  processExplorer: ProcessExplorerRpc,
   rootPid: number,
-  platform: number,
+  pidMap?: unknown,
 ): Promise<readonly ProcessInfo[]> => {
-  if (platform === PlatformType.Electron) {
-    const pidMap = await MainProcess.invoke('CreatePidMap.createPidMap')
-    return ProcessExplorerModule.invoke(
+  if (pidMap) {
+    return processExplorer.invoke(
       'ListProcessesWithMemoryUsage.listProcessesWithMemoryUsage',
       rootPid,
       false,
       pidMap,
     )
   }
-  return ProcessExplorerModule.invoke(
+  return processExplorer.invoke(
     'ListProcessesWithMemoryUsage.listProcessesWithMemoryUsage',
     rootPid,
     false,
   )
+}
+
+const getRootPid = async (
+  processExplorer: ProcessExplorerRpc,
+  rootPid: number,
+  includeElectronData: boolean,
+): Promise<number> => {
+  if (rootPid !== -1) {
+    return rootPid
+  }
+  return processExplorer.invoke('ProcessId.getMainProcessId', {
+    includeElectronData,
+  })
 }
 
 export const refresh = async (
@@ -48,23 +70,46 @@ export const refresh = async (
   try {
     await InitializeProcessExplorer.initializeProcessExplorer(state.platform)
     const includeElectronData = state.platform === PlatformType.Electron
-    const rootPid =
-      state.rootPid === -1
-        ? await ProcessExplorerModule.invoke('ProcessId.getMainProcessId', {
-            includeElectronData,
-          })
-        : state.rootPid
-    const processes = await listProcesses(rootPid, state.platform)
+    const rootPid = await getRootPid(
+      ProcessExplorerModule,
+      state.rootPid,
+      includeElectronData,
+    )
+    const pidMap = includeElectronData
+      ? await MainProcess.invoke('CreatePidMap.createPidMap')
+      : undefined
+    const processes = await listProcesses(
+      ProcessExplorerModule,
+      rootPid,
+      pidMap,
+    )
     const frontendMemoryProcesses = state.includeFrontendMemoryUsage
       ? await GetFrontendMemoryUsage.getFrontendMemoryUsage(rootPid)
       : []
     const allProcesses = [...processes, ...frontendMemoryProcesses]
-    const displayedProcesses =
+    const localProcesses =
       state.platform === PlatformType.Electron
         ? ReparentSharedProcessChildren.reparentSharedProcessChildren(
             allProcesses,
           )
         : allProcesses
+    let displayedProcesses = localProcesses
+    if (
+      state.platform === PlatformType.Electron &&
+      RemoteProcessExplorer.has()
+    ) {
+      const remoteRootPid = await getRootPid(RemoteProcessExplorer, -1, false)
+      const remoteProcesses = await listProcesses(
+        RemoteProcessExplorer,
+        remoteRootPid,
+      )
+      displayedProcesses = GroupProcesses.groupProcesses(
+        localProcesses,
+        rootPid,
+        remoteProcesses,
+        remoteRootPid,
+      )
+    }
     const visibleProcesses = GetVisibleProcesses.getVisibleProcesses(
       displayedProcesses,
       state.collapsedPids,

--- a/packages/process-explorer-worker/src/parts/RemoteProcessExplorer/RemoteProcessExplorer.ts
+++ b/packages/process-explorer-worker/src/parts/RemoteProcessExplorer/RemoteProcessExplorer.ts
@@ -1,0 +1,39 @@
+import type { Rpc } from '@lvce-editor/rpc'
+
+interface State {
+  rpc: Rpc | undefined
+}
+
+const state: State = {
+  rpc: undefined,
+}
+
+export const invoke = async (
+  method: string,
+  ...params: readonly unknown[]
+): Promise<any> => {
+  const { rpc } = state
+  if (!rpc) {
+    throw new Error('RemoteProcessExplorerModule is not initialized')
+  }
+  return rpc.invoke(method, ...params)
+}
+
+export const set = (newRpc: Rpc): void => {
+  state.rpc = newRpc
+}
+
+export const has = (): boolean => {
+  const { rpc } = state
+  return Boolean(rpc)
+}
+
+export const clear = (): void => {
+  state.rpc = undefined
+}
+
+export const dispose = async (): Promise<void> => {
+  const { rpc } = state
+  state.rpc = undefined
+  await rpc?.dispose()
+}

--- a/packages/process-explorer-worker/src/parts/RenderItems/RenderItems.ts
+++ b/packages/process-explorer-worker/src/parts/RenderItems/RenderItems.ts
@@ -123,10 +123,14 @@ const getRowDom = (
       index,
       getPaddingLeft(process),
     ),
-    ...getCellDom(ClassNames.Cell, String(process.pid), index),
     ...getCellDom(
       ClassNames.Cell,
-      FormatMemory.formatMemory(process.memory),
+      process.synthetic ? '' : String(process.pid),
+      index,
+    ),
+    ...getCellDom(
+      ClassNames.Cell,
+      process.synthetic ? '' : FormatMemory.formatMemory(process.memory),
       index,
     ),
   ]

--- a/packages/process-explorer-worker/src/parts/ToggleIndex/ToggleIndex.ts
+++ b/packages/process-explorer-worker/src/parts/ToggleIndex/ToggleIndex.ts
@@ -10,9 +10,10 @@ export const toggleIndex = (
   if (!process || process.flags === ProcessFlag.None) {
     return state
   }
-  const collapsedPids = state.collapsedPids.includes(process.pid)
-    ? state.collapsedPids.filter((pid) => pid !== process.pid)
-    : [...state.collapsedPids, process.pid]
+  const treeId = process.treeId ?? process.pid
+  const collapsedPids = state.collapsedPids.includes(treeId)
+    ? state.collapsedPids.filter((pid) => pid !== treeId)
+    : [...state.collapsedPids, treeId]
   const visibleProcesses = GetVisibleProcesses.getVisibleProcesses(
     state.processes,
     collapsedPids,

--- a/packages/process-explorer-worker/test/GetMenuEntries.test.ts
+++ b/packages/process-explorer-worker/test/GetMenuEntries.test.ts
@@ -77,3 +77,23 @@ test('getMenuEntries - missing process', () => {
   }
   expect(GetMenuEntries.getMenuEntries(state)).toEqual([])
 })
+
+test('getMenuEntries - process group', () => {
+  const state = {
+    ...createDefaultState(),
+    focusedIndex: 0,
+    visibleProcesses: [
+      {
+        cmd: 'Local',
+        depth: 1,
+        flags: 1,
+        memory: 0,
+        name: 'Local',
+        pid: 0,
+        ppid: 0,
+        synthetic: true as const,
+      },
+    ],
+  }
+  expect(GetMenuEntries.getMenuEntries(state)).toEqual([])
+})

--- a/packages/process-explorer-worker/test/GroupProcesses.test.ts
+++ b/packages/process-explorer-worker/test/GroupProcesses.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from '@jest/globals'
+import * as GetVisibleProcesses from '../src/parts/GetVisibleProcesses/GetVisibleProcesses.ts'
+import * as GroupProcesses from '../src/parts/GroupProcesses/GroupProcesses.ts'
+
+const localProcesses = [
+  { cmd: 'local main', memory: 1, name: 'main', pid: 1, ppid: 0 },
+  { cmd: 'local child', memory: 2, name: 'child', pid: 2, ppid: 1 },
+]
+
+const remoteProcesses = [
+  { cmd: 'remote main', memory: 3, name: 'remote-main', pid: 1, ppid: 0 },
+  { cmd: 'remote child', memory: 4, name: 'remote-child', pid: 2, ppid: 1 },
+]
+
+test('groupProcesses creates independent local and remote trees', () => {
+  const processes = GroupProcesses.groupProcesses(
+    localProcesses,
+    1,
+    remoteProcesses,
+    1,
+  )
+  const visible = GetVisibleProcesses.getVisibleProcesses(processes, [], 1)
+
+  expect(
+    visible.map(({ depth, name, pid, source, treeId }) => ({
+      depth,
+      name,
+      pid,
+      source,
+      treeId,
+    })),
+  ).toEqual([
+    { depth: 1, name: 'Local', pid: 0, source: 'local', treeId: 'local:group' },
+    { depth: 2, name: 'main', pid: 1, source: 'local', treeId: 'local:1' },
+    { depth: 3, name: 'child', pid: 2, source: 'local', treeId: 'local:2' },
+    {
+      depth: 1,
+      name: 'Remote',
+      pid: 0,
+      source: 'remote',
+      treeId: 'remote:group',
+    },
+    {
+      depth: 2,
+      name: 'remote-main',
+      pid: 1,
+      source: 'remote',
+      treeId: 'remote:1',
+    },
+    {
+      depth: 3,
+      name: 'remote-child',
+      pid: 2,
+      source: 'remote',
+      treeId: 'remote:2',
+    },
+  ])
+})
+
+test('groupProcesses collapses one source without collapsing matching pids', () => {
+  const processes = GroupProcesses.groupProcesses(
+    localProcesses,
+    1,
+    remoteProcesses,
+    1,
+  )
+  const visible = GetVisibleProcesses.getVisibleProcesses(
+    processes,
+    ['local:1'],
+    1,
+  )
+
+  expect(visible.map((process) => process.treeId)).toEqual([
+    'local:group',
+    'local:1',
+    'remote:group',
+    'remote:1',
+    'remote:2',
+  ])
+})

--- a/packages/process-explorer-worker/test/InitializeProcessExplorer.test.ts
+++ b/packages/process-explorer-worker/test/InitializeProcessExplorer.test.ts
@@ -20,14 +20,24 @@ const launchProcessExplorerNode = jest.fn(
 const handleProcessExplorerRpcClose = jest.fn(async () => {})
 const disposeMainProcess = jest.fn(async () => {})
 const disposeProcessExplorer = jest.fn(async () => {})
+const disposeRemoteProcessExplorer = jest.fn(async () => {})
 const setMainProcess = jest.fn()
 const clear = jest.fn()
+const clearRemoteProcessExplorer = jest.fn()
+const hasRemoteProcessExplorer = jest.fn(() => false)
+const setRemoteProcessExplorer = jest.fn()
 const setProcessExplorer = jest.fn()
+const rendererInvoke = jest.fn<(method: string) => Promise<boolean>>(
+  async (_method: string) => false,
+)
 
 jest.unstable_mockModule('@lvce-editor/rpc-registry', () => ({
   MainProcess: {
     dispose: disposeMainProcess,
     set: setMainProcess,
+  },
+  RendererWorker: {
+    invoke: rendererInvoke,
   },
 }))
 
@@ -58,6 +68,16 @@ jest.unstable_mockModule(
     clear,
     dispose: disposeProcessExplorer,
     set: setProcessExplorer,
+  }),
+)
+
+jest.unstable_mockModule(
+  '../src/parts/RemoteProcessExplorer/RemoteProcessExplorer.ts',
+  () => ({
+    clear: clearRemoteProcessExplorer,
+    dispose: disposeRemoteProcessExplorer,
+    has: hasRemoteProcessExplorer,
+    set: setRemoteProcessExplorer,
   }),
 )
 
@@ -104,6 +124,32 @@ test('initializeProcessExplorer - remote', async () => {
   expect(setProcessExplorer).toHaveBeenCalledWith(nodeRpc)
 })
 
+test('initializeProcessExplorer - electron with remote workspace', async () => {
+  rendererInvoke.mockResolvedValueOnce(true)
+
+  await InitializeProcessExplorer.initializeProcessExplorer(
+    PlatformType.Electron,
+  )
+
+  expect(launchProcessExplorerElectron).toHaveBeenCalledTimes(1)
+  expect(launchProcessExplorerNode).toHaveBeenCalledTimes(1)
+  expect(setProcessExplorer).toHaveBeenCalledWith(processExplorerRpc)
+  expect(setRemoteProcessExplorer).toHaveBeenCalledWith(nodeRpc)
+})
+
+test('initializeProcessExplorer - disposes remote rpc after workspace disconnects', async () => {
+  rendererInvoke.mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+  await InitializeProcessExplorer.initializeProcessExplorer(
+    PlatformType.Electron,
+  )
+
+  await InitializeProcessExplorer.initializeProcessExplorer(
+    PlatformType.Electron,
+  )
+
+  expect(disposeRemoteProcessExplorer).toHaveBeenCalledTimes(1)
+})
+
 test('initializeProcessExplorer - remote connection closes', async () => {
   await InitializeProcessExplorer.initializeProcessExplorer(PlatformType.Remote)
   const onClose = launchProcessExplorerNode.mock.calls[0][0]
@@ -135,6 +181,7 @@ test('dispose - electron rpcs', async () => {
 
   expect(disposeMainProcess).toHaveBeenCalledTimes(1)
   expect(disposeProcessExplorer).toHaveBeenCalledTimes(1)
+  expect(disposeRemoteProcessExplorer).toHaveBeenCalledTimes(1)
 })
 
 test('dispose - remote rpc', async () => {

--- a/packages/process-explorer-worker/test/ProcessCommands.test.ts
+++ b/packages/process-explorer-worker/test/ProcessCommands.test.ts
@@ -6,6 +6,7 @@ import * as DebugProcess from '../src/parts/DebugProcess/DebugProcess.ts'
 import * as GetVisibleProcesses from '../src/parts/GetVisibleProcesses/GetVisibleProcesses.ts'
 import * as KillProcess from '../src/parts/KillProcess/KillProcess.ts'
 import * as ProcessExplorer from '../src/parts/ProcessExplorer/ProcessExplorer.ts'
+import * as RemoteProcessExplorer from '../src/parts/RemoteProcessExplorer/RemoteProcessExplorer.ts'
 
 interface DisposableMockRpc {
   [Symbol.dispose](): void
@@ -18,6 +19,17 @@ const registerProcessExplorerMock = (
   return {
     [Symbol.dispose](): void {
       ProcessExplorer.clear()
+    },
+  }
+}
+
+const registerRemoteProcessExplorerMock = (
+  commandMap: Record<string, unknown>,
+): DisposableMockRpc => {
+  RemoteProcessExplorer.set(createMockRpc({ commandMap }))
+  return {
+    [Symbol.dispose](): void {
+      RemoteProcessExplorer.clear()
     },
   }
 }
@@ -60,6 +72,51 @@ test('killProcess - missing process', async () => {
   const state = createDefaultState()
   await expect(KillProcess.killProcess(state, 0)).resolves.toBe(state)
   expect(kill).not.toHaveBeenCalled()
+})
+
+test('killProcess - remote process', async () => {
+  const kill = jest.fn()
+  using _mockRemoteRpc = registerRemoteProcessExplorerMock({
+    'Process.kill': kill,
+  })
+  const state = {
+    ...createDefaultState(),
+    visibleProcesses: [
+      {
+        cmd: 'remote child',
+        depth: 2,
+        flags: 0,
+        memory: 1,
+        name: 'remote-child',
+        pid: 2,
+        ppid: 1,
+        source: 'remote' as const,
+      },
+    ],
+  }
+
+  await expect(KillProcess.killProcess(state, 0)).resolves.toBe(state)
+  expect(kill).toHaveBeenCalledWith(2)
+})
+
+test('killProcess - process group', async () => {
+  const state = {
+    ...createDefaultState(),
+    visibleProcesses: [
+      {
+        cmd: 'Local',
+        depth: 1,
+        flags: 1,
+        memory: 0,
+        name: 'Local',
+        pid: 0,
+        ppid: 0,
+        synthetic: true as const,
+      },
+    ],
+  }
+
+  await expect(KillProcess.killProcess(state, 0)).resolves.toBe(state)
 })
 
 test('killProcess - does not wait for process explorer rpc response', async () => {

--- a/packages/process-explorer-worker/test/Refresh.test.ts
+++ b/packages/process-explorer-worker/test/Refresh.test.ts
@@ -19,6 +19,8 @@ const { createDefaultState } =
   await import('../src/parts/CreateDefaultState/CreateDefaultState.ts')
 const ProcessExplorerModule =
   await import('../src/parts/ProcessExplorer/ProcessExplorer.ts')
+const RemoteProcessExplorer =
+  await import('../src/parts/RemoteProcessExplorer/RemoteProcessExplorer.ts')
 const Refresh = await import('../src/parts/Refresh/Refresh.ts')
 
 interface DisposableMockRpc {
@@ -63,6 +65,17 @@ const registerMainProcessMock = (
   return {
     [Symbol.dispose](): void {
       MainProcess.set(createMockRpc({ commandMap: {} }))
+    },
+  }
+}
+
+const registerRemoteProcessExplorerMock = (
+  commandMap: Record<string, unknown>,
+): DisposableMockRpc => {
+  RemoteProcessExplorer.set(createMockRpc({ commandMap }))
+  return {
+    [Symbol.dispose](): void {
+      RemoteProcessExplorer.clear()
     },
   }
 }
@@ -163,6 +176,49 @@ test('refresh - success - electron', async () => {
   expect(getMainProcessId).toHaveBeenCalledWith({ includeElectronData: true })
   expect(createPidMap).toHaveBeenCalledTimes(1)
   expect(listProcessesWithMemoryUsage).toHaveBeenCalledWith(1, false, pidMap)
+})
+
+test('refresh - electron with remote workspace', async () => {
+  const localProcesses = [processes[0], processes[1]]
+  const remoteProcesses = [
+    { cmd: 'remote main', memory: 3, name: 'remote-main', pid: 1, ppid: 0 },
+    { cmd: 'remote child', memory: 4, name: 'remote-child', pid: 2, ppid: 1 },
+  ]
+  using _mockRpc = registerProcessExplorerMock({
+    'ListProcessesWithMemoryUsage.listProcessesWithMemoryUsage': jest.fn(
+      () => localProcesses,
+    ),
+    'ProcessId.getMainProcessId': jest.fn(() => 1),
+  })
+  using _mockRemoteRpc = registerRemoteProcessExplorerMock({
+    'ListProcessesWithMemoryUsage.listProcessesWithMemoryUsage': jest.fn(
+      () => remoteProcesses,
+    ),
+    'ProcessId.getMainProcessId': jest.fn(() => 1),
+  })
+  using _mockMainProcessRpc = registerMainProcessMock({
+    'CreatePidMap.createPidMap': jest.fn(() => ({})),
+  })
+
+  const result = await Refresh.refresh({
+    ...createDefaultState(),
+    platform: PlatformType.Electron,
+  })
+
+  expect(
+    result.visibleProcesses.map(({ depth, name, source }) => ({
+      depth,
+      name,
+      source,
+    })),
+  ).toEqual([
+    { depth: 1, name: 'Local', source: 'local' },
+    { depth: 2, name: 'main', source: 'local' },
+    { depth: 3, name: 'child', source: 'local' },
+    { depth: 1, name: 'Remote', source: 'remote' },
+    { depth: 2, name: 'remote-main', source: 'remote' },
+    { depth: 3, name: 'remote-child', source: 'remote' },
+  ])
 })
 
 test('refresh - groups conceptual processes below shared process on electron', async () => {

--- a/packages/process-explorer-worker/test/RemoteProcessExplorer.test.ts
+++ b/packages/process-explorer-worker/test/RemoteProcessExplorer.test.ts
@@ -1,0 +1,27 @@
+import type { Rpc } from '@lvce-editor/rpc'
+import { expect, jest, test } from '@jest/globals'
+import * as RemoteProcessExplorer from '../src/parts/RemoteProcessExplorer/RemoteProcessExplorer.ts'
+
+const createRpc = (): Rpc => ({
+  dispose: jest.fn(async () => {}),
+  invoke: jest.fn(async () => 'result'),
+  invokeAndTransfer: jest.fn(async () => {}),
+  send: jest.fn(),
+})
+
+test('set, invoke and dispose', async () => {
+  const rpc = createRpc()
+  RemoteProcessExplorer.set(rpc)
+
+  expect(RemoteProcessExplorer.has()).toBe(true)
+  await expect(RemoteProcessExplorer.invoke('test', 1)).resolves.toBe('result')
+  expect(rpc.invoke).toHaveBeenCalledWith('test', 1)
+
+  await RemoteProcessExplorer.dispose()
+
+  expect(rpc.dispose).toHaveBeenCalledTimes(1)
+  expect(RemoteProcessExplorer.has()).toBe(false)
+  await expect(RemoteProcessExplorer.invoke('test')).rejects.toThrow(
+    'RemoteProcessExplorerModule is not initialized',
+  )
+})


### PR DESCRIPTION
Show separate Local and Remote process trees when an Electron workspace is connected to a remote machine. Keep process identities and actions scoped to their source machine.