### PR TITLE
fix: widen process name column for web contents views

### DIFF
--- a/packages/process-explorer-worker/src/parts/RenderItems/RenderItems.ts
+++ b/packages/process-explorer-worker/src/parts/RenderItems/RenderItems.ts
@@ -107,7 +107,7 @@ const getHeaderDom = (
     ...['Name', 'PID', 'Memory'].flatMap((label, index) => [
       {
         ...headerCellNode,
-        ...(index === 0 && nameColumnWidth ? { width: nameColumnWidth } : {}),
+        ...(index === 0 && nameColumnWidth && { width: nameColumnWidth }),
       },
       text(label),
     ]),

--- a/packages/process-explorer-worker/src/parts/RenderItems/RenderItems.ts
+++ b/packages/process-explorer-worker/src/parts/RenderItems/RenderItems.ts
@@ -88,12 +88,27 @@ const getCellDom = (
   ]
 }
 
-const getHeaderDom = (): readonly VirtualDomNode[] => {
+const getNameColumnWidth = (
+  visibleProcesses: readonly VisibleProcess[],
+): string | undefined => {
+  const hasWebContentsView = visibleProcesses.some((process) =>
+    process.name.toLowerCase().includes('webcontentsview'),
+  )
+  return hasWebContentsView ? '40%' : undefined
+}
+
+const getHeaderDom = (
+  visibleProcesses: readonly VisibleProcess[],
+): readonly VirtualDomNode[] => {
+  const nameColumnWidth = getNameColumnWidth(visibleProcesses)
   return [
     tableHeadNode,
     headerRowNode,
-    ...['Name', 'PID', 'Memory'].flatMap((label) => [
-      headerCellNode,
+    ...['Name', 'PID', 'Memory'].flatMap((label, index) => [
+      {
+        ...headerCellNode,
+        ...(index === 0 && nameColumnWidth ? { width: nameColumnWidth } : {}),
+      },
       text(label),
     ]),
   ]
@@ -223,7 +238,7 @@ const getTableDom = (
       tabIndex: TabIndex.Focusable,
       type: VirtualDomElements.Table,
     },
-    ...getHeaderDom(),
+    ...getHeaderDom(visibleProcesses),
     ...getBodyDom(state),
   ]
 }

--- a/packages/process-explorer-worker/test/RenderItems.test.ts
+++ b/packages/process-explorer-worker/test/RenderItems.test.ts
@@ -71,6 +71,40 @@ test('renderItems - populated table', () => {
       title: 'node child.js',
     }),
   )
+  const nameHeader = result[2].find(
+    (node: VirtualDomNode) => node.className === 'ProcessExplorerHeaderCell',
+  )
+  expect(nameHeader).not.toHaveProperty('width')
+})
+
+test('renderItems - widens the name column for a webcontentsview process', () => {
+  const state = {
+    ...createDefaultState(),
+    initial: false,
+    visibleProcesses: GetVisibleProcesses.getVisibleProcesses(
+      [
+        ...processes,
+        {
+          cmd: 'renderer',
+          memory: 1,
+          name: 'renderer (webcontentsview, soundcloud.com)',
+          pid: 5,
+          ppid: 1,
+        },
+      ],
+      [],
+      1,
+    ),
+  }
+  const result = RenderItems.renderItems(createDefaultState(), state)
+  const headers = result[2].filter(
+    (node: VirtualDomNode) => node.className === 'ProcessExplorerHeaderCell',
+  )
+
+  expect(headers).toHaveLength(3)
+  expect(headers[0]).toHaveProperty('width', '40%')
+  expect(headers[1]).not.toHaveProperty('width')
+  expect(headers[2]).not.toHaveProperty('width')
 })
 
 test('renderItems - collapsed row', () => {


### PR DESCRIPTION
Widen the Process Explorer name column to 40% whenever a visible process is a webcontentsview, leaving the existing equal-column layout unchanged otherwise. Includes render regression coverage for both layouts.