### PR TITLE
feature: take process heap snapshots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6043,6 +6043,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
@@ -15126,9 +15136,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -15560,7 +15570,8 @@
         "@lvce-editor/assert": "^1.7.0",
         "@lvce-editor/rpc": "^6.8.0",
         "@lvce-editor/rpc-registry": "^9.34.0",
-        "@lvce-editor/verror": "^1.7.0"
+        "@lvce-editor/verror": "^1.7.0",
+        "ws": "^8.21.3"
       },
       "bin": {
         "process-explorer": "bin/processExplorer.js"
@@ -15568,6 +15579,7 @@
       "devDependencies": {
         "@jest/globals": "^30.4.1",
         "@types/node": "^26.1.0",
+        "@types/ws": "^8.18.1",
         "jest": "^30.4.2",
         "ts-jest": "^29.4.11"
       },

--- a/packages/e2e/src/viewlet.process-explorer.take-heap-snapshot.ts
+++ b/packages/e2e/src/viewlet.process-explorer.take-heap-snapshot.ts
@@ -1,0 +1,44 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.process-explorer.take-heap-snapshot'
+
+export const skip = navigator.platform === 'Win32'
+
+const maxRefreshAttempts = 20
+
+export const test: Test = async ({ Command, ContextMenu, expect, Locator }) => {
+  await Command.execute('Developer.openProcessExplorer')
+  const marker = `process-explorer-e2e-heap-snapshot-${Date.now()}`
+
+  try {
+    await Command.execute('ProcessExplorer.createE2eFixtureProcess', marker)
+    const row = Locator(`.ProcessExplorerRow[title*="${marker}"]`)
+    for (let i = 0; i < maxRefreshAttempts; i++) {
+      await Command.execute('ProcessExplorer.refresh')
+      try {
+        await expect(row).toBeVisible()
+        break
+      } catch {
+        // keep refreshing while the process appears in ps
+      }
+    }
+    await expect(row).toBeVisible()
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    // eslint-disable-next-line e2e/no-direct-click -- focuses the exact fixture process
+    await row.click()
+    await Command.execute('ProcessExplorer.handleContextMenu')
+    const takeHeapSnapshot = Locator('.MenuItem', {
+      hasText: 'Take Heap Snapshot',
+    })
+    await expect(takeHeapSnapshot).toBeVisible()
+    await ContextMenu.selectItem('Take Heap Snapshot')
+
+    const heapSnapshotTab = Locator('.MainTabSelected[title$=".heapsnapshot"]')
+    await expect(heapSnapshotTab).toBeVisible()
+  } finally {
+    await Command.execute('ProcessExplorer.disposeE2eFixtureProcess', marker)
+    await Command.execute('ProcessExplorer.setRootProcessId', -1)
+    await Command.execute('ProcessExplorer.refresh')
+  }
+}

--- a/packages/process-explorer-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/process-explorer-worker/src/parts/CommandMap/CommandMap.ts
@@ -31,6 +31,7 @@ import * as Rerender from '../Rerender/Rerender.ts'
 import * as SetError from '../SetError/SetError.ts'
 import * as SetRootProcessId from '../SetRootProcessId/SetRootProcessId.ts'
 import * as SetUpdateInterval from '../SetUpdateInterval/SetUpdateInterval.ts'
+import * as TakeHeapSnapshot from '../TakeHeapSnapshot/TakeHeapSnapshot.ts'
 
 const handleDirectMessagePort = (
   port: MessagePort,
@@ -116,6 +117,9 @@ export const commandMap = {
   ),
   'ProcessExplorer.setUpdateInterval': ProcessExplorerStates.wrapCommand(
     SetUpdateInterval.setUpdateInterval,
+  ),
+  'ProcessExplorer.takeHeapSnapshot': ProcessExplorerStates.wrapCommand(
+    TakeHeapSnapshot.takeHeapSnapshot,
   ),
   'ProcessExplorer.terminate': terminate,
   'ProcessExplorer.update': ProcessExplorerStates.wrapCommand(Refresh.refresh),

--- a/packages/process-explorer-worker/src/parts/GetMenuEntries/GetMenuEntries.ts
+++ b/packages/process-explorer-worker/src/parts/GetMenuEntries/GetMenuEntries.ts
@@ -28,6 +28,13 @@ export const getMenuEntries = (
       id: 'debugProcess',
       label: MenuItemLabels.DebugProcess,
     })
+    menuEntries.push({
+      args: [state.focusedIndex],
+      command: 'ProcessExplorer.takeHeapSnapshot',
+      flags: MenuItemFlags.None,
+      id: 'takeHeapSnapshot',
+      label: MenuItemLabels.TakeHeapSnapshot,
+    })
   }
   return menuEntries
 }

--- a/packages/process-explorer-worker/src/parts/MenuItemLabels/MenuItemLabels.ts
+++ b/packages/process-explorer-worker/src/parts/MenuItemLabels/MenuItemLabels.ts
@@ -1,3 +1,5 @@
 export const KillProcess = 'Kill Process'
 
 export const DebugProcess = 'Debug Process'
+
+export const TakeHeapSnapshot = 'Take Heap Snapshot'

--- a/packages/process-explorer-worker/src/parts/TakeHeapSnapshot/TakeHeapSnapshot.ts
+++ b/packages/process-explorer-worker/src/parts/TakeHeapSnapshot/TakeHeapSnapshot.ts
@@ -1,0 +1,24 @@
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import type { ProcessExplorerState } from '../ProcessExplorerState/ProcessExplorerState.ts'
+import * as ProcessExplorer from '../ProcessExplorer/ProcessExplorer.ts'
+import * as RemoteProcessExplorer from '../RemoteProcessExplorer/RemoteProcessExplorer.ts'
+
+export const takeHeapSnapshot = async (
+  state: ProcessExplorerState,
+  index?: number,
+): Promise<ProcessExplorerState> => {
+  const { focusedIndex, visibleProcesses } = state
+  const process = visibleProcesses[index ?? focusedIndex]
+  if (!process || process.synthetic) {
+    return state
+  }
+  const processExplorer =
+    process.source === 'remote' ? RemoteProcessExplorer : ProcessExplorer
+  const path = await processExplorer.invoke(
+    'Process.takeHeapSnapshot',
+    process.pid,
+    process.cmd,
+  )
+  await RendererWorker.invoke('Main.openUri', path)
+  return state
+}

--- a/packages/process-explorer-worker/test/CommandMap.test.ts
+++ b/packages/process-explorer-worker/test/CommandMap.test.ts
@@ -29,4 +29,7 @@ test('commandMap exposes context menu commands', () => {
   expect(CommandMap.commandMap['ProcessExplorer.setRootProcessId']).toEqual(
     expect.any(Function),
   )
+  expect(CommandMap.commandMap['ProcessExplorer.takeHeapSnapshot']).toEqual(
+    expect.any(Function),
+  )
 })

--- a/packages/process-explorer-worker/test/GetMenuEntries.test.ts
+++ b/packages/process-explorer-worker/test/GetMenuEntries.test.ts
@@ -49,6 +49,13 @@ test('getMenuEntries - debuggable process', () => {
       id: 'debugProcess',
       label: 'Debug Process',
     },
+    {
+      args: [1],
+      command: 'ProcessExplorer.takeHeapSnapshot',
+      flags: MenuItemFlags.None,
+      id: 'takeHeapSnapshot',
+      label: 'Take Heap Snapshot',
+    },
   ])
 })
 

--- a/packages/process-explorer-worker/test/ProcessCommands.test.ts
+++ b/packages/process-explorer-worker/test/ProcessCommands.test.ts
@@ -7,6 +7,7 @@ import * as GetVisibleProcesses from '../src/parts/GetVisibleProcesses/GetVisibl
 import * as KillProcess from '../src/parts/KillProcess/KillProcess.ts'
 import * as ProcessExplorer from '../src/parts/ProcessExplorer/ProcessExplorer.ts'
 import * as RemoteProcessExplorer from '../src/parts/RemoteProcessExplorer/RemoteProcessExplorer.ts'
+import * as TakeHeapSnapshot from '../src/parts/TakeHeapSnapshot/TakeHeapSnapshot.ts'
 
 interface DisposableMockRpc {
   [Symbol.dispose](): void
@@ -170,4 +171,62 @@ test('debugProcess - missing process', async () => {
   const state = createDefaultState()
   await expect(DebugProcess.debugProcess(state, 0)).resolves.toBe(state)
   expect(attachDebugger).not.toHaveBeenCalled()
+})
+
+test('takeHeapSnapshot', async () => {
+  const takeHeapSnapshot = jest.fn<
+    (_pid: number, _command: string) => Promise<string>
+  >(async () => '/tmp/snapshot.heapsnapshot')
+  const openUri = jest.fn()
+  using _processExplorerRpc = registerProcessExplorerMock({
+    'Process.takeHeapSnapshot': takeHeapSnapshot,
+  })
+  using _rendererWorkerRpc = RendererWorker.registerMockRpc({
+    'Main.openUri': openUri,
+  })
+  const state = {
+    ...createDefaultState(),
+    visibleProcesses: GetVisibleProcesses.getVisibleProcesses(processes, [], 1),
+  }
+
+  await expect(TakeHeapSnapshot.takeHeapSnapshot(state, 1)).resolves.toBe(state)
+  expect(takeHeapSnapshot).toHaveBeenCalledWith(2, 'node child.js')
+  expect(openUri).toHaveBeenCalledWith('/tmp/snapshot.heapsnapshot')
+})
+
+test('takeHeapSnapshot - remote process', async () => {
+  const takeHeapSnapshot = jest.fn<
+    (_pid: number, _command: string) => Promise<string>
+  >(async () => '/tmp/remote.heapsnapshot')
+  const openUri = jest.fn()
+  using _remoteProcessExplorerRpc = registerRemoteProcessExplorerMock({
+    'Process.takeHeapSnapshot': takeHeapSnapshot,
+  })
+  using _rendererWorkerRpc = RendererWorker.registerMockRpc({
+    'Main.openUri': openUri,
+  })
+  const state = {
+    ...createDefaultState(),
+    visibleProcesses: [
+      {
+        cmd: 'node remote.js',
+        depth: 2,
+        flags: 0,
+        memory: 1,
+        name: 'remote-child',
+        pid: 4,
+        ppid: 1,
+        source: 'remote' as const,
+      },
+    ],
+  }
+
+  await expect(TakeHeapSnapshot.takeHeapSnapshot(state, 0)).resolves.toBe(state)
+  expect(takeHeapSnapshot).toHaveBeenCalledWith(4, 'node remote.js')
+  expect(openUri).toHaveBeenCalledWith('/tmp/remote.heapsnapshot')
+})
+
+test('takeHeapSnapshot - missing process', async () => {
+  const state = createDefaultState()
+  await expect(TakeHeapSnapshot.takeHeapSnapshot(state, 0)).resolves.toBe(state)
 })

--- a/packages/process-explorer/package.json
+++ b/packages/process-explorer/package.json
@@ -25,7 +25,8 @@
     "@lvce-editor/assert": "^1.7.0",
     "@lvce-editor/rpc": "^6.8.0",
     "@lvce-editor/rpc-registry": "^9.34.0",
-    "@lvce-editor/verror": "^1.7.0"
+    "@lvce-editor/verror": "^1.7.0",
+    "ws": "^8.21.3"
   },
   "optionalDependencies": {
     "@vscode/windows-process-tree": "^0.8.0"
@@ -61,6 +62,7 @@
   "devDependencies": {
     "@jest/globals": "^30.4.1",
     "@types/node": "^26.1.0",
+    "@types/ws": "^8.18.1",
     "jest": "^30.4.2",
     "ts-jest": "^29.4.11"
   }

--- a/packages/process-explorer/src/parts/CommandMap/CommandMap.ts
+++ b/packages/process-explorer/src/parts/CommandMap/CommandMap.ts
@@ -6,6 +6,7 @@ import * as HandleWebSocket from '../HandleWebSocket/HandleWebSocket.ts'
 import * as KillProcess from '../KillProcess/KillProcess.ts'
 import * as ListProcessesWithMemoryUsage from '../ListProcessesWithMemoryUsage/ListProcessesWithMemoryUsage.ts'
 import * as ProcessId from '../ProcessId/ProcessId.ts'
+import * as TakeHeapSnapshot from '../TakeHeapSnapshot/TakeHeapSnapshot.ts'
 
 export const commandMap = {
   'HandleElectronMessagePort.handleElectronMessagePort':
@@ -19,5 +20,6 @@ export const commandMap = {
   'Process.disposeE2eFixtureProcess':
     E2eFixtureProcess.disposeE2eFixtureProcess,
   'Process.kill': KillProcess.killProcess,
+  'Process.takeHeapSnapshot': TakeHeapSnapshot.takeHeapSnapshot,
   'ProcessId.getMainProcessId': ProcessId.getMainProcessId,
 }

--- a/packages/process-explorer/src/parts/E2eFixtureProcess/E2eFixtureProcess.ts
+++ b/packages/process-explorer/src/parts/E2eFixtureProcess/E2eFixtureProcess.ts
@@ -8,14 +8,18 @@ const fixtureScript =
 const fixtureProcesses = new Map<string, number>()
 
 export const createE2eFixtureProcess = (marker: string): number => {
-  const childProcess = spawn(process.execPath, ['-e', fixtureScript, marker], {
-    env: {
-      ...process.env,
-      ELECTRON_RUN_AS_NODE: '1',
+  const childProcess = spawn(
+    process.execPath,
+    ['--inspect=9000', '-e', fixtureScript, marker],
+    {
+      env: {
+        ...process.env,
+        ELECTRON_RUN_AS_NODE: '1',
+      },
+      shell: false,
+      stdio: 'ignore',
     },
-    shell: false,
-    stdio: 'ignore',
-  })
+  )
   childProcess.unref()
   if (!childProcess.pid) {
     throw new Error('Failed to create e2e fixture process')

--- a/packages/process-explorer/src/parts/GetInspectorPortsFromCommand/GetInspectorPortsFromCommand.ts
+++ b/packages/process-explorer/src/parts/GetInspectorPortsFromCommand/GetInspectorPortsFromCommand.ts
@@ -1,0 +1,18 @@
+const defaultInspectorPorts = [9000, 9229]
+
+const inspectOptionRegex = /--inspect(?:-brk|-wait|-port)?(?:=|\s+)([^\s"']+)/g
+const digitsRegex = /^\d+$/
+
+export const getInspectorPortsFromCommand = (
+  command: string,
+): readonly number[] => {
+  const ports = new Set(defaultInspectorPorts)
+  for (const match of command.matchAll(inspectOptionRegex)) {
+    const portText = match[1].split(':').at(-1) || ''
+    const port = digitsRegex.test(portText) ? Number(portText) : 0
+    if (port > 0 && port <= 65_535) {
+      ports.add(port)
+    }
+  }
+  return [...ports]
+}

--- a/packages/process-explorer/src/parts/GetInspectorProcessId/GetInspectorProcessId.ts
+++ b/packages/process-explorer/src/parts/GetInspectorProcessId/GetInspectorProcessId.ts
@@ -1,0 +1,59 @@
+import { WebSocket, type RawData } from 'ws'
+
+interface RuntimeEvaluateMessage {
+  readonly id?: number
+  readonly result?: {
+    readonly result?: {
+      readonly value?: unknown
+    }
+  }
+}
+
+const commandId = 1
+const timeoutMs = 2000
+
+export const getInspectorProcessId = (url: string): Promise<number> => {
+  return new Promise((resolve) => {
+    const webSocket = new WebSocket(url)
+    let settled = false
+    const finish = (pid: number): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      webSocket.close()
+      resolve(pid)
+    }
+    const timeout = setTimeout(finish, timeoutMs, 0)
+
+    webSocket.on('error', () => finish(0))
+    webSocket.on('close', () => finish(0))
+    webSocket.on('message', (data: RawData) => {
+      try {
+        const message = JSON.parse(
+          (data as Buffer).toString(),
+        ) as RuntimeEvaluateMessage
+        if (message.id !== commandId) {
+          return
+        }
+        const value = message.result?.result?.value
+        finish(typeof value === 'number' ? value : 0)
+      } catch {
+        finish(0)
+      }
+    })
+    webSocket.on('open', () => {
+      webSocket.send(
+        JSON.stringify({
+          id: commandId,
+          method: 'Runtime.evaluate',
+          params: {
+            expression: 'process.pid',
+            returnByValue: true,
+          },
+        }),
+      )
+    })
+  })
+}

--- a/packages/process-explorer/src/parts/GetInspectorWebSocketUrl/GetInspectorWebSocketUrl.ts
+++ b/packages/process-explorer/src/parts/GetInspectorWebSocketUrl/GetInspectorWebSocketUrl.ts
@@ -1,0 +1,70 @@
+import { setTimeout } from 'node:timers/promises'
+import * as GetInspectorPortsFromCommand from '../GetInspectorPortsFromCommand/GetInspectorPortsFromCommand.ts'
+import * as GetInspectorProcessId from '../GetInspectorProcessId/GetInspectorProcessId.ts'
+import * as GetProcessListeningPorts from '../GetProcessListeningPorts/GetProcessListeningPorts.ts'
+
+interface InspectorTarget {
+  readonly title?: string
+  readonly webSocketDebuggerUrl?: string
+}
+
+const maxAttempts = 50
+const retryDelay = 100
+
+export const getInspectorWebSocketUrlAtPort = async (
+  pid: number,
+  port: number,
+): Promise<string> => {
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/json/list`, {
+      signal: AbortSignal.timeout(500),
+    })
+    if (!response.ok) {
+      return ''
+    }
+    const targets = (await response.json()) as readonly InspectorTarget[]
+    if (!Array.isArray(targets)) {
+      return ''
+    }
+    const pidSuffix = `[${pid}]`
+    for (const target of targets) {
+      const { title = '', webSocketDebuggerUrl = '' } = target
+      if (!webSocketDebuggerUrl) {
+        continue
+      }
+      if (title.endsWith(pidSuffix)) {
+        return webSocketDebuggerUrl
+      }
+      const inspectorPid =
+        await GetInspectorProcessId.getInspectorProcessId(webSocketDebuggerUrl)
+      if (inspectorPid === pid) {
+        return webSocketDebuggerUrl
+      }
+    }
+    return ''
+  } catch {
+    return ''
+  }
+}
+
+export const getInspectorWebSocketUrl = async (
+  pid: number,
+  command: string,
+): Promise<string> => {
+  const commandPorts =
+    GetInspectorPortsFromCommand.getInspectorPortsFromCommand(command)
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const listeningPorts =
+      await GetProcessListeningPorts.getProcessListeningPorts(pid)
+    const ports = new Set([...commandPorts, ...listeningPorts])
+    const urls = await Promise.all(
+      Array.from(ports, (port) => getInspectorWebSocketUrlAtPort(pid, port)),
+    )
+    const url = urls.find(Boolean)
+    if (url) {
+      return url
+    }
+    await setTimeout(retryDelay)
+  }
+  throw new Error(`Could not find the inspector for process ${pid}`)
+}

--- a/packages/process-explorer/src/parts/GetLinuxProcessListeningPorts/GetLinuxProcessListeningPorts.ts
+++ b/packages/process-explorer/src/parts/GetLinuxProcessListeningPorts/GetLinuxProcessListeningPorts.ts
@@ -1,0 +1,73 @@
+import { readFile, readdir, readlink } from 'node:fs/promises'
+
+const socketRegex = /^socket:\[(\d+)\]$/
+const whitespaceRegex = /\s+/
+
+export const parseProcNetTcp = (
+  content: string,
+  socketInodes: ReadonlySet<string>,
+): readonly number[] => {
+  const ports: number[] = []
+  const lines = content.split('\n').slice(1)
+  for (const line of lines) {
+    const fields = line.trim().split(whitespaceRegex)
+    if (fields.length < 10 || fields[3] !== '0A') {
+      continue
+    }
+    const inode = fields[9]
+    if (!socketInodes.has(inode)) {
+      continue
+    }
+    const separatorIndex = fields[1].lastIndexOf(':')
+    const port = Number.parseInt(fields[1].slice(separatorIndex + 1), 16)
+    if (port > 0) {
+      ports.push(port)
+    }
+  }
+  return ports
+}
+
+const getSocketInodes = async (pid: number): Promise<ReadonlySet<string>> => {
+  const directory = `/proc/${pid}/fd`
+  const entries = await readdir(directory)
+  const links = await Promise.allSettled(
+    entries.map((entry) => readlink(`${directory}/${entry}`)),
+  )
+  const inodes = new Set<string>()
+  for (const link of links) {
+    if (link.status !== 'fulfilled') {
+      continue
+    }
+    const match = link.value.match(socketRegex)
+    if (match) {
+      inodes.add(match[1])
+    }
+  }
+  return inodes
+}
+
+const readNetworkTable = async (path: string): Promise<string> => {
+  try {
+    return await readFile(path, 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+export const getLinuxProcessListeningPorts = async (
+  pid: number,
+): Promise<readonly number[]> => {
+  try {
+    const socketInodes = await getSocketInodes(pid)
+    const [tcp, tcp6] = await Promise.all([
+      readNetworkTable(`/proc/${pid}/net/tcp`),
+      readNetworkTable(`/proc/${pid}/net/tcp6`),
+    ])
+    return [
+      ...parseProcNetTcp(tcp, socketInodes),
+      ...parseProcNetTcp(tcp6, socketInodes),
+    ]
+  } catch {
+    return []
+  }
+}

--- a/packages/process-explorer/src/parts/GetProcessListeningPorts/GetProcessListeningPorts.ts
+++ b/packages/process-explorer/src/parts/GetProcessListeningPorts/GetProcessListeningPorts.ts
@@ -1,0 +1,10 @@
+import * as GetLinuxProcessListeningPorts from '../GetLinuxProcessListeningPorts/GetLinuxProcessListeningPorts.ts'
+
+export const getProcessListeningPorts = async (
+  pid: number,
+): Promise<readonly number[]> => {
+  if (process.platform !== 'linux') {
+    return []
+  }
+  return GetLinuxProcessListeningPorts.getLinuxProcessListeningPorts(pid)
+}

--- a/packages/process-explorer/src/parts/Signal/Signal.ts
+++ b/packages/process-explorer/src/parts/Signal/Signal.ts
@@ -1,2 +1,3 @@
 export const SIGINT = 'SIGINT'
 export const SIGTERM = 'SIGTERM'
+export const SIGUSR1 = 'SIGUSR1'

--- a/packages/process-explorer/src/parts/TakeHeapSnapshot/TakeHeapSnapshot.ts
+++ b/packages/process-explorer/src/parts/TakeHeapSnapshot/TakeHeapSnapshot.ts
@@ -1,0 +1,30 @@
+import { createWriteStream } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { WebSocket } from 'ws'
+import * as GetInspectorWebSocketUrl from '../GetInspectorWebSocketUrl/GetInspectorWebSocketUrl.ts'
+import * as Process from '../Process/Process.ts'
+import * as Signal from '../Signal/Signal.ts'
+import * as TakeHeapSnapshotWithCdp from '../TakeHeapSnapshotWithCdp/TakeHeapSnapshotWithCdp.ts'
+
+export const takeHeapSnapshot = async (
+  pid: number,
+  command: string,
+): Promise<string> => {
+  Process.kill(pid, Signal.SIGUSR1)
+  const inspectorUrl = await GetInspectorWebSocketUrl.getInspectorWebSocketUrl(
+    pid,
+    command,
+  )
+  const path = join(tmpdir(), `lvce-process-${pid}-${Date.now()}.heapsnapshot`)
+  const webSocket = new WebSocket(inspectorUrl)
+  const output = createWriteStream(path)
+  try {
+    await TakeHeapSnapshotWithCdp.takeHeapSnapshotWithCdp(webSocket, output)
+    return path
+  } catch (error) {
+    await rm(path, { force: true })
+    throw error
+  }
+}

--- a/packages/process-explorer/src/parts/TakeHeapSnapshotWithCdp/TakeHeapSnapshotWithCdp.ts
+++ b/packages/process-explorer/src/parts/TakeHeapSnapshotWithCdp/TakeHeapSnapshotWithCdp.ts
@@ -1,0 +1,90 @@
+import type { WriteStream } from 'node:fs'
+import type { RawData, WebSocket } from 'ws'
+
+interface CdpMessage {
+  readonly error?: {
+    readonly message: string
+  }
+  readonly id?: number
+  readonly method?: string
+  readonly params?: {
+    readonly chunk: string
+  }
+}
+
+const commandId = 1
+const timeoutMs = 5 * 60 * 1000
+
+export const takeHeapSnapshotWithCdp = (
+  webSocket: WebSocket,
+  output: WriteStream,
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const timeout = setTimeout(() => {
+      fail(new Error('Timed out while taking the heap snapshot'))
+    }, timeoutMs)
+
+    const dispose = (): void => {
+      clearTimeout(timeout)
+      webSocket.close()
+    }
+
+    const fail = (error: Error): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      output.destroy()
+      dispose()
+      reject(error)
+    }
+
+    output.on('error', fail)
+    webSocket.on('error', fail)
+    webSocket.on('close', () => {
+      fail(new Error('Inspector connection closed while taking heap snapshot'))
+    })
+    webSocket.on('message', (data: RawData) => {
+      try {
+        const message = JSON.parse((data as Buffer).toString()) as CdpMessage
+        if (message.method === 'HeapProfiler.addHeapSnapshotChunk') {
+          const chunk = message.params?.chunk as string
+          if (!output.write(chunk)) {
+            webSocket.pause()
+            output.once('drain', () => webSocket.resume())
+          }
+          return
+        }
+        if (message.id !== commandId) {
+          return
+        }
+        if (message.error) {
+          fail(new Error(message.error.message))
+          return
+        }
+        output.end(() => {
+          if (settled) {
+            return
+          }
+          settled = true
+          dispose()
+          resolve()
+        })
+      } catch (error) {
+        fail(new Error('Failed to handle inspector message', { cause: error }))
+      }
+    })
+    webSocket.on('open', () => {
+      webSocket.send(
+        JSON.stringify({
+          id: commandId,
+          method: 'HeapProfiler.takeHeapSnapshot',
+          params: {
+            reportProgress: false,
+          },
+        }),
+      )
+    })
+  })
+}

--- a/packages/process-explorer/test/CommandMapRpc.test.ts
+++ b/packages/process-explorer/test/CommandMapRpc.test.ts
@@ -6,6 +6,7 @@ import * as HandleMessagePort from '../src/parts/HandleMessagePort/HandleMessage
 import * as HandleSocket from '../src/parts/HandleSocket/HandleSocket.ts'
 import * as HandleWebSocket from '../src/parts/HandleWebSocket/HandleWebSocket.ts'
 import * as KillProcess from '../src/parts/KillProcess/KillProcess.ts'
+import * as TakeHeapSnapshot from '../src/parts/TakeHeapSnapshot/TakeHeapSnapshot.ts'
 
 test('commandMap exposes rpc handoff commands', () => {
   expect(CommandMap.commandMap['Process.createE2eFixtureProcess']).toBe(
@@ -29,4 +30,7 @@ test('commandMap exposes rpc handoff commands', () => {
     HandleWebSocket.handleWebSocket,
   )
   expect(CommandMap.commandMap['Process.kill']).toBe(KillProcess.killProcess)
+  expect(CommandMap.commandMap['Process.takeHeapSnapshot']).toBe(
+    TakeHeapSnapshot.takeHeapSnapshot,
+  )
 })

--- a/packages/process-explorer/test/E2eFixtureProcess.test.ts
+++ b/packages/process-explorer/test/E2eFixtureProcess.test.ts
@@ -25,7 +25,7 @@ test('createE2eFixtureProcess', () => {
   expect(E2eFixtureProcess.createE2eFixtureProcess('test-marker')).toBe(123)
   expect(childProcess.spawn).toHaveBeenCalledWith(
     process.execPath,
-    ['-e', expect.any(String), 'test-marker'],
+    ['--inspect=9000', '-e', expect.any(String), 'test-marker'],
     expect.objectContaining({
       env: expect.objectContaining({
         ELECTRON_RUN_AS_NODE: '1',

--- a/packages/process-explorer/test/GetInspectorPortsFromCommand.test.ts
+++ b/packages/process-explorer/test/GetInspectorPortsFromCommand.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@jest/globals'
+import * as GetInspectorPortsFromCommand from '../src/parts/GetInspectorPortsFromCommand/GetInspectorPortsFromCommand.ts'
+
+test('returns the common inspector ports', () => {
+  expect(
+    GetInspectorPortsFromCommand.getInspectorPortsFromCommand('node app.js'),
+  ).toEqual([9000, 9229])
+})
+
+test('finds inspector ports in node options', () => {
+  expect(
+    GetInspectorPortsFromCommand.getInspectorPortsFromCommand(
+      'node --inspect=127.0.0.1:9230 --inspect-port 9231 app.js',
+    ),
+  ).toEqual([9000, 9229, 9230, 9231])
+})
+
+test('ignores random and invalid inspector ports', () => {
+  expect(
+    GetInspectorPortsFromCommand.getInspectorPortsFromCommand(
+      'node --inspect-port=0 --inspect=localhost:99999 --inspect-wait=localhost app.js',
+    ),
+  ).toEqual([9000, 9229])
+})

--- a/packages/process-explorer/test/GetInspectorProcessId.test.ts
+++ b/packages/process-explorer/test/GetInspectorProcessId.test.ts
@@ -1,0 +1,77 @@
+import type { AddressInfo } from 'node:net'
+import { expect, test } from '@jest/globals'
+import { once } from 'node:events'
+import { type WebSocket, WebSocketServer } from 'ws'
+import * as GetInspectorProcessId from '../src/parts/GetInspectorProcessId/GetInspectorProcessId.ts'
+
+interface TestServer {
+  readonly close: () => Promise<void>
+  readonly url: string
+}
+
+const createTestServer = async (
+  respond: (webSocket: WebSocket) => void,
+): Promise<TestServer> => {
+  const server = new WebSocketServer({ port: 0 })
+  await once(server, 'listening')
+  server.on('connection', (webSocket) => {
+    webSocket.on('message', () => respond(webSocket))
+  })
+  const { port } = server.address() as AddressInfo
+  return {
+    close: () =>
+      new Promise((resolve) => {
+        server.close(() => resolve())
+      }),
+    url: `ws://127.0.0.1:${port}`,
+  }
+}
+
+test('gets the process id from the inspector', async () => {
+  const server = await createTestServer((webSocket) => {
+    webSocket.send(
+      JSON.stringify({ id: 1, result: { result: { value: 123 } } }),
+    )
+  })
+  try {
+    await expect(
+      GetInspectorProcessId.getInspectorProcessId(server.url),
+    ).resolves.toBe(123)
+  } finally {
+    await server.close()
+  }
+})
+
+test('returns zero for a non-number process id', async () => {
+  const server = await createTestServer((webSocket) => {
+    webSocket.send(
+      JSON.stringify({ id: 1, result: { result: { value: 'unknown' } } }),
+    )
+  })
+  try {
+    await expect(
+      GetInspectorProcessId.getInspectorProcessId(server.url),
+    ).resolves.toBe(0)
+  } finally {
+    await server.close()
+  }
+})
+
+test('returns zero for an invalid inspector message', async () => {
+  const server = await createTestServer((webSocket) => {
+    webSocket.send('invalid json')
+  })
+  try {
+    await expect(
+      GetInspectorProcessId.getInspectorProcessId(server.url),
+    ).resolves.toBe(0)
+  } finally {
+    await server.close()
+  }
+})
+
+test('returns zero when the inspector cannot be reached', async () => {
+  await expect(
+    GetInspectorProcessId.getInspectorProcessId('ws://127.0.0.1:1'),
+  ).resolves.toBe(0)
+})

--- a/packages/process-explorer/test/GetInspectorWebSocketUrl.test.ts
+++ b/packages/process-explorer/test/GetInspectorWebSocketUrl.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+import * as GetInspectorWebSocketUrl from '../src/parts/GetInspectorWebSocketUrl/GetInspectorWebSocketUrl.ts'
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+test('gets the matching node inspector websocket url', async () => {
+  const fetch = jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+    Response.json([
+      {
+        title: 'node[123]',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9229/target',
+      },
+    ]),
+  )
+
+  await expect(
+    GetInspectorWebSocketUrl.getInspectorWebSocketUrlAtPort(123, 9229),
+  ).resolves.toBe('ws://127.0.0.1:9229/target')
+  expect(fetch).toHaveBeenCalledWith('http://127.0.0.1:9229/json/list', {
+    signal: expect.any(AbortSignal),
+  })
+})
+
+test('ignores inspector targets for other processes', async () => {
+  jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+    Response.json([
+      {
+        title: 'node[456]',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9229/target',
+      },
+    ]),
+  )
+
+  await expect(
+    GetInspectorWebSocketUrl.getInspectorWebSocketUrlAtPort(123, 9229),
+  ).resolves.toBe('')
+})
+
+test('ignores unsuccessful inspector responses', async () => {
+  jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response('', {
+      status: 500,
+    }),
+  )
+
+  await expect(
+    GetInspectorWebSocketUrl.getInspectorWebSocketUrlAtPort(123, 9229),
+  ).resolves.toBe('')
+})
+
+test('ignores invalid inspector target lists', async () => {
+  jest.spyOn(globalThis, 'fetch').mockResolvedValue(Response.json({}))
+
+  await expect(
+    GetInspectorWebSocketUrl.getInspectorWebSocketUrlAtPort(123, 9229),
+  ).resolves.toBe('')
+})
+
+test('finds the inspector using command ports', async () => {
+  jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+    Response.json([
+      {
+        title: 'node[123]',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9230/target',
+      },
+    ]),
+  )
+
+  await expect(
+    GetInspectorWebSocketUrl.getInspectorWebSocketUrl(
+      123,
+      'node --inspect-port=9230 app.js',
+    ),
+  ).resolves.toBe('ws://127.0.0.1:9230/target')
+})
+
+test('ignores failed inspector requests', async () => {
+  jest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('not listening'))
+
+  await expect(
+    GetInspectorWebSocketUrl.getInspectorWebSocketUrlAtPort(123, 9229),
+  ).resolves.toBe('')
+})

--- a/packages/process-explorer/test/GetLinuxProcessListeningPorts.test.ts
+++ b/packages/process-explorer/test/GetLinuxProcessListeningPorts.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@jest/globals'
+import * as GetLinuxProcessListeningPorts from '../src/parts/GetLinuxProcessListeningPorts/GetLinuxProcessListeningPorts.ts'
+
+const header =
+  '  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode'
+
+test('parseProcNetTcp returns listening ports owned by the process', () => {
+  const content = `${header}\n   0: 0100007F:2405 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000 0 12345 1\n   1: 0100007F:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000 0 67890 1\n`
+
+  expect(
+    GetLinuxProcessListeningPorts.parseProcNetTcp(content, new Set(['12345'])),
+  ).toEqual([9221])
+})
+
+test('parseProcNetTcp ignores non-listening and malformed rows', () => {
+  const content = `${header}\ninvalid\n   0: 0100007F:2405 00000000:0000 01 00000000:00000000 00:00000000 00000000  1000 0 12345 1\n`
+
+  expect(
+    GetLinuxProcessListeningPorts.parseProcNetTcp(content, new Set(['12345'])),
+  ).toEqual([])
+})

--- a/packages/process-explorer/test/TakeHeapSnapshot.integration.test.ts
+++ b/packages/process-explorer/test/TakeHeapSnapshot.integration.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@jest/globals'
+import { spawn } from 'node:child_process'
+import { once } from 'node:events'
+import { readFile, rm } from 'node:fs/promises'
+import { setTimeout } from 'node:timers/promises'
+import * as TakeHeapSnapshot from '../src/parts/TakeHeapSnapshot/TakeHeapSnapshot.ts'
+
+test('takes a heap snapshot from a node process', async () => {
+  if (process.platform === 'win32') {
+    return
+  }
+  const child = spawn(
+    process.execPath,
+    ['-e', 'setInterval(() => {}, 1000)', 'snapshot-target'],
+    {
+      stdio: 'ignore',
+    },
+  )
+  let snapshotPath = ''
+  try {
+    expect(child.pid).toEqual(expect.any(Number))
+    await setTimeout(200)
+    snapshotPath = await TakeHeapSnapshot.takeHeapSnapshot(
+      child.pid as number,
+      `${process.execPath} -e "setInterval(() => {}, 1000)" snapshot-target`,
+    )
+    const content = JSON.parse(await readFile(snapshotPath, 'utf8'))
+    expect(content.snapshot.meta).toEqual(expect.any(Object))
+    expect(content.nodes.length).toBeGreaterThan(0)
+  } finally {
+    if (child.exitCode === null) {
+      const exitPromise = once(child, 'exit')
+      child.kill()
+      await exitPromise
+    }
+    if (snapshotPath) {
+      await rm(snapshotPath, { force: true })
+    }
+  }
+})

--- a/packages/process-explorer/test/TakeHeapSnapshotWithCdp.test.ts
+++ b/packages/process-explorer/test/TakeHeapSnapshotWithCdp.test.ts
@@ -1,0 +1,125 @@
+import type { AddressInfo } from 'node:net'
+import { expect, test } from '@jest/globals'
+import { once } from 'node:events'
+import { createWriteStream } from 'node:fs'
+import { readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { WebSocket, type WebSocket as WebSocketType, WebSocketServer } from 'ws'
+import * as TakeHeapSnapshotWithCdp from '../src/parts/TakeHeapSnapshotWithCdp/TakeHeapSnapshotWithCdp.ts'
+
+interface TestServer {
+  readonly close: () => Promise<void>
+  readonly url: string
+}
+
+const createTestServer = async (
+  respond: (webSocket: WebSocketType) => void,
+): Promise<TestServer> => {
+  const server = new WebSocketServer({ port: 0 })
+  await once(server, 'listening')
+  server.on('connection', (webSocket) => {
+    webSocket.on('message', () => respond(webSocket))
+  })
+  const { port } = server.address() as AddressInfo
+  return {
+    close: () =>
+      new Promise((resolve) => {
+        server.close(() => resolve())
+      }),
+    url: `ws://127.0.0.1:${port}`,
+  }
+}
+
+const getSnapshotPath = (): string => {
+  return join(
+    tmpdir(),
+    `lvce-process-cdp-test-${process.pid}-${Date.now()}-${Math.random()}.heapsnapshot`,
+  )
+}
+
+test('streams heap snapshot chunks into the output file', async () => {
+  const server = await createTestServer((webSocket) => {
+    webSocket.send(JSON.stringify({ id: 2, result: {} }))
+    webSocket.send(
+      JSON.stringify({
+        method: 'HeapProfiler.addHeapSnapshotChunk',
+        params: { chunk: 'first' },
+      }),
+    )
+    webSocket.send(
+      JSON.stringify({
+        method: 'HeapProfiler.addHeapSnapshotChunk',
+        params: { chunk: 'second' },
+      }),
+    )
+    webSocket.send(JSON.stringify({ id: 1, result: {} }))
+  })
+  const path = getSnapshotPath()
+  try {
+    await TakeHeapSnapshotWithCdp.takeHeapSnapshotWithCdp(
+      new WebSocket(server.url),
+      createWriteStream(path),
+    )
+    await expect(readFile(path, 'utf8')).resolves.toBe('firstsecond')
+  } finally {
+    await server.close()
+    await rm(path, { force: true })
+  }
+})
+
+test('reports an inspector error', async () => {
+  const server = await createTestServer((webSocket) => {
+    webSocket.send(
+      JSON.stringify({ error: { message: 'snapshot failed' }, id: 1 }),
+    )
+  })
+  const path = getSnapshotPath()
+  try {
+    await expect(
+      TakeHeapSnapshotWithCdp.takeHeapSnapshotWithCdp(
+        new WebSocket(server.url),
+        createWriteStream(path),
+      ),
+    ).rejects.toThrow('snapshot failed')
+  } finally {
+    await server.close()
+    await rm(path, { force: true })
+  }
+})
+
+test('reports an invalid inspector message', async () => {
+  const server = await createTestServer((webSocket) => {
+    webSocket.send('invalid json')
+  })
+  const path = getSnapshotPath()
+  try {
+    await expect(
+      TakeHeapSnapshotWithCdp.takeHeapSnapshotWithCdp(
+        new WebSocket(server.url),
+        createWriteStream(path),
+      ),
+    ).rejects.toThrow('Failed to handle inspector message')
+  } finally {
+    await server.close()
+    await rm(path, { force: true })
+  }
+})
+
+test('reports an inspector connection that closes early', async () => {
+  const server = await createTestServer((webSocket) => {
+    webSocket.close()
+  })
+  const path = getSnapshotPath()
+  try {
+    await expect(
+      TakeHeapSnapshotWithCdp.takeHeapSnapshotWithCdp(
+        new WebSocket(server.url),
+        createWriteStream(path),
+      ),
+    ).rejects.toThrow('Inspector connection closed while taking heap snapshot')
+  } finally {
+    await server.close()
+    await rm(path, { force: true })
+  }
+})


### PR DESCRIPTION
Adds a **Take Heap Snapshot** action to the Process Explorer context menu for debuggable Node.js processes.

The action sends `SIGUSR1`, discovers and verifies the target Node inspector, streams `HeapProfiler.takeHeapSnapshot` chunks to a temporary `.heapsnapshot` file, and opens that URI in the editor main area. Inspector discovery supports common and command-line ports, plus dynamically assigned listening ports on Linux.

Includes focused worker/backend coverage, a real Node/CDP integration test, and an end-to-end Process Explorer test.